### PR TITLE
Update WorldEdit Maven Repo & use Java 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Set up JDK 8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         with:
-          java-version: 8
+          java-version: '11'
+          distribution: 'adopt-hotspot'
       - name: Cache SonarCloud packages
         uses: actions/cache@v1
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     </repository>
     <repository>
       <id>sk89q-repo</id>
-      <url>http://maven.sk89q.com/repo/</url>
+      <url>https://maven.sk89q.com/repo/</url>
     </repository>
   </repositories>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -83,8 +83,8 @@
       <url>https://repo.codemc.org/repository/maven-public/</url>
     </repository>
     <repository>
-      <id>sk89q-repo</id>
-      <url>https://maven.sk89q.com/repo/</url>
+      <id>enginehub-repo</id>
+      <url>https://maven.enginehub.org/repo/</url>
     </repository>
   </repositories>
   <dependencies>


### PR DESCRIPTION
Newer Maven releases don't allow use of http endpoints. Bump this to the secure https endpoint to prevent dependency resolution failures. See https://maven.apache.org/docs/3.8.1/release-notes.html

The worldedit team also recommends using the enginehub maven URL, though they should be functionally [equivalent](https://worldguard.enginehub.org/en/latest/developer/dependency/).

Finally, newer Maven versions require Java 11. Minecraft also requires newer Java (1.17 needs JRE 16), so bump to 11 -- the latest LTS version.