### PR TITLE
Add HikariCP connection pool for MySQL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     }
     compileOnly 'org.spigotmc:spigot-api:1.17-R0.1-SNAPSHOT'
     implementation 'org.bstats:bstats-bukkit-lite:1.7'
+    implementation 'com.zaxxer:HikariCP:4.0.3'
 }
 
 jar {
@@ -51,6 +52,7 @@ shadowJar {
     dependencies {
         // #toString because #getGroup technically returns an Object
         relocate('org.bstats', project.group.toString())
+        relocate('com.zaxxer', project.group.toString())
     }
     archiveClassifier.set(null)
 }

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,10 @@
                   <pattern>org.bstats</pattern>
                   <shadedPattern>net.coreprotect</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>com.zaxxer</pattern>
+                  <shadedPattern>net.coreprotect</shadedPattern>
+                </relocation>
               </relocations>
             </configuration>
           </execution>
@@ -110,6 +114,11 @@
           <artifactId>bukkit</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP</artifactId>
+      <version>4.0.3</version>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/java/net/coreprotect/CoreProtectAPI.java
+++ b/src/main/java/net/coreprotect/CoreProtectAPI.java
@@ -445,8 +445,7 @@ public class CoreProtectAPI extends Queue {
             return null;
         }
 
-        try {
-            Connection connection = Database.getConnection(false, 1000);
+        try (Connection connection = Database.getConnection(false, 1000)) {
             if (connection != null) {
                 Statement statement = connection.createStatement();
                 boolean restrictWorld = false;
@@ -488,7 +487,6 @@ public class CoreProtectAPI extends Queue {
                 }
 
                 statement.close();
-                connection.close();
             }
         }
         catch (Exception e) {

--- a/src/main/java/net/coreprotect/command/LookupCommand.java
+++ b/src/main/java/net/coreprotect/command/LookupCommand.java
@@ -324,9 +324,8 @@ public class LookupCommand {
             class BasicThread implements Runnable {
                 @Override
                 public void run() {
-                    try {
+                    try (Connection connection = Database.getConnection(true)) {
                         ConfigHandler.lookupThrottle.put(player2.getName(), new Object[] { true, System.currentTimeMillis() });
-                        Connection connection = Database.getConnection(true);
                         if (connection != null) {
                             Statement statement = connection.createStatement();
                             String blockdata = ChestTransactionLookup.performLookup(command.getName(), statement, location, player2, p2, finalLimit, false);
@@ -339,7 +338,6 @@ public class LookupCommand {
                                 Chat.sendComponent(player2, blockdata);
                             }
                             statement.close();
-                            connection.close();
                         }
                         else {
                             Chat.sendMessage(player2, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.DATABASE_BUSY));
@@ -422,9 +420,8 @@ public class LookupCommand {
             class BasicThread implements Runnable {
                 @Override
                 public void run() {
-                    try {
+                    try (Connection connection = Database.getConnection(true)) {
                         ConfigHandler.lookupThrottle.put(player2.getName(), new Object[] { true, System.currentTimeMillis() });
-                        Connection connection = Database.getConnection(true);
                         if (connection != null) {
                             Statement statement = connection.createStatement();
                             if (t == 8) {
@@ -461,7 +458,6 @@ public class LookupCommand {
                                 }
                             }
                             statement.close();
-                            connection.close();
                         }
                         else {
                             Chat.sendMessage(player2, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.DATABASE_BUSY));
@@ -681,7 +677,7 @@ public class LookupCommand {
                     class BasicThread2 implements Runnable {
                         @Override
                         public void run() {
-                            try {
+                            try (Connection connection = Database.getConnection(true)) {
                                 ConfigHandler.lookupThrottle.put(player2.getName(), new Object[] { true, System.currentTimeMillis() });
 
                                 List<String> uuidList = new ArrayList<>();
@@ -699,7 +695,6 @@ public class LookupCommand {
                                 ConfigHandler.lookupAlist.put(player2.getName(), finalArgAction);
                                 ConfigHandler.lookupRadius.put(player2.getName(), radius);
 
-                                Connection connection = Database.getConnection(true);
                                 if (connection != null) {
                                     Statement statement = connection.createStatement();
                                     String baduser = "";
@@ -950,7 +945,6 @@ public class LookupCommand {
                                         Chat.sendMessage(player2, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.USER_NOT_FOUND, baduser));
                                     }
                                     statement.close();
-                                    connection.close();
                                 }
                                 else {
                                     Chat.sendMessage(player2, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.DATABASE_BUSY));

--- a/src/main/java/net/coreprotect/command/PurgeCommand.java
+++ b/src/main/java/net/coreprotect/command/PurgeCommand.java
@@ -1,10 +1,7 @@
 package net.coreprotect.command;
 
 import java.io.File;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
+import java.sql.*;
 import java.text.NumberFormat;
 import java.util.Arrays;
 import java.util.List;
@@ -94,14 +91,12 @@ public class PurgeCommand extends Consumer {
 
             @Override
             public void run() {
-                try {
+                try (Connection connection = Database.getConnection(false, 500)) {
                     int timestamp = (int) (System.currentTimeMillis() / 1000L);
                     int ptime = timestamp - seconds;
                     long removed = 0;
 
-                    Connection connection = null;
                     for (int i = 0; i <= 5; i++) {
-                        connection = Database.getConnection(false, 500);
                         if (connection != null) {
                             break;
                         }
@@ -343,8 +338,6 @@ public class PurgeCommand extends Consumer {
                             preparedStmt.close();
                         }
                     }
-
-                    connection.close();
 
                     if (abort) {
                         if (!Config.getGlobal().MYSQL) {

--- a/src/main/java/net/coreprotect/command/RollbackRestoreCommand.java
+++ b/src/main/java/net/coreprotect/command/RollbackRestoreCommand.java
@@ -310,11 +310,10 @@ public class RollbackRestoreCommand {
                         class BasicThread2 implements Runnable {
                             @Override
                             public void run() {
-                                try {
+                                try (Connection connection = Database.getConnection(false, 1000)) {
                                     ConfigHandler.lookupThrottle.put(player.getName(), new Object[] { true, System.currentTimeMillis() });
                                     int action = finalAction;
                                     Location location = locationFinal;
-                                    Connection connection = Database.getConnection(false, 1000);
                                     if (connection != null) {
                                         Statement statement = connection.createStatement();
                                         String baduser = "";
@@ -407,7 +406,6 @@ public class RollbackRestoreCommand {
                                             Chat.sendMessage(player2, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.USER_NOT_FOUND, baduser));
                                         }
                                         statement.close();
-                                        connection.close();
                                     }
                                     else {
                                         Chat.sendMessage(player2, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.DATABASE_BUSY));

--- a/src/main/java/net/coreprotect/config/ConfigHandler.java
+++ b/src/main/java/net/coreprotect/config/ConfigHandler.java
@@ -224,6 +224,8 @@ public class ConfigHandler extends Queue {
             config.addDataSourceProperty("rewriteBatchedStatements", "true");
             config.addDataSourceProperty("cacheServerConfiguration", "true");
             config.addDataSourceProperty("maintainTimeStats", "false");
+            /* Disable SSL to suppress the unverified server identity warning */
+            config.addDataSourceProperty("useSSL", "false");
 
             ConfigHandler.hikariDataSource = new HikariDataSource(config);
         }

--- a/src/main/java/net/coreprotect/config/ConfigHandler.java
+++ b/src/main/java/net/coreprotect/config/ConfigHandler.java
@@ -14,6 +14,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -50,6 +52,7 @@ public class ConfigHandler extends Queue {
     public static String username = "root";
     public static String password = "";
     public static String prefix = "co_";
+    public static HikariDataSource hikariDataSource = null;
     public static final boolean isSpigot = Util.isSpigot();
     public static final boolean isPaper = Util.isPaper();
     public static volatile boolean serverRunning = false;
@@ -198,6 +201,25 @@ public class ConfigHandler extends Queue {
             catch (Exception e) {
                 e.printStackTrace();
             }
+        } else {
+            HikariConfig config = new HikariConfig();
+            config.setJdbcUrl("jdbc:mysql://" + ConfigHandler.host + ":" + ConfigHandler.port + "/" + ConfigHandler.database);
+            config.setUsername(ConfigHandler.username);
+            config.setPassword(ConfigHandler.password);
+            config.addDataSourceProperty("characterEncoding", "UTF-8");
+            config.addDataSourceProperty("connectionTimeout", "10000");
+            /* https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration */
+            /* https://cdn.oreillystatic.com/en/assets/1/event/21/Connector_J%20Performance%20Gems%20Presentation.pdf */
+            config.addDataSourceProperty("cachePrepStmts", "true");
+            config.addDataSourceProperty("prepStmtCacheSize", "250");
+            config.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
+            config.addDataSourceProperty("useServerPrepStmts", "true");
+            config.addDataSourceProperty("useLocalSessionState", "true");
+            config.addDataSourceProperty("rewriteBatchedStatements", "true");
+            config.addDataSourceProperty("cacheServerConfiguration", "true");
+            config.addDataSourceProperty("maintainTimeStats", "false");
+
+            ConfigHandler.hikariDataSource = new HikariDataSource(config);
         }
 
         if (ConfigHandler.serverRunning) {

--- a/src/main/java/net/coreprotect/consumer/Consumer.java
+++ b/src/main/java/net/coreprotect/consumer/Consumer.java
@@ -18,7 +18,6 @@ import net.coreprotect.consumer.process.Process;
 public class Consumer extends Process implements Runnable, Thread.UncaughtExceptionHandler {
 
     private static Thread consumerThread = null;
-    public static volatile boolean resetConnection = false;
     public static volatile int currentConsumer = 0;
     public static volatile boolean isPaused = false;
     public static volatile boolean transacting = false;
@@ -103,12 +102,6 @@ public class Consumer extends Process implements Runnable, Thread.UncaughtExcept
         try {
             while ((ConfigHandler.serverRunning || ConfigHandler.converterRunning) && (Consumer.isPaused || ConfigHandler.purgeRunning || Consumer.consumer_id.get(process_id)[1] == 1)) {
                 pausedSuccess = true;
-                if (Consumer.isPaused || ConfigHandler.purgeRunning) {
-                    if (connection != null) {
-                        connection.close();
-                        connection = null;
-                    }
-                }
                 Thread.sleep(100);
             }
         }

--- a/src/main/java/net/coreprotect/database/Database.java
+++ b/src/main/java/net/coreprotect/database/Database.java
@@ -138,15 +138,7 @@ public class Database extends Queue {
             }
             if (Config.getGlobal().MYSQL) {
                 try {
-                    /* Using useServerPrepStmts, cachePrepStmts, and rewriteBatchedStatements per https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration */
-                    String database = "jdbc:mysql://" + ConfigHandler.host + ":" + ConfigHandler.port + "/" + ConfigHandler.database + "?useUnicode=true&characterEncoding=utf-8&connectTimeout=10000&useSSL=false&allowPublicKeyRetrieval=true&useCursorFetch=true&useLocalSessionState=true&rewriteBatchedStatements=true&maintainTimeStats=false";
-                    connection = DriverManager.getConnection(database, ConfigHandler.username, ConfigHandler.password);
-
-                    /* Recommended implementation per https://dev.mysql.com/doc/refman/5.0/en/charset-applications.html & https://dev.mysql.com/doc/refman/5.0/en/charset-syntax.html */
-                    Statement statement = connection.createStatement();
-                    statement.executeUpdate("SET NAMES 'utf8mb4'"); // COLLATE 'utf8mb4mb4_general_ci'
-                    statement.close();
-
+                    connection = ConfigHandler.hikariDataSource.getConnection();
                     ConfigHandler.databaseReachable = true;
                 }
                 catch (Exception e) {

--- a/src/main/java/net/coreprotect/database/Database.java
+++ b/src/main/java/net/coreprotect/database/Database.java
@@ -308,8 +308,7 @@ public class Database extends Queue {
 
         if (Config.getGlobal().MYSQL) {
             boolean success = false;
-            try {
-                Connection connection = Database.getConnection(true, true, true, 0);
+            try (Connection connection = Database.getConnection(true, true, true, 0)) {
                 if (connection != null) {
                     String index = "";
                     Statement statement = connection.createStatement();
@@ -349,7 +348,6 @@ public class Database extends Queue {
                         initializeTables(prefix, statement);
                     }
                     statement.close();
-                    connection.close();
                     success = true;
                 }
             }
@@ -361,8 +359,7 @@ public class Database extends Queue {
             }
         }
         if (!Config.getGlobal().MYSQL) {
-            try {
-                Connection connection = Database.getConnection(true, 0);
+            try (Connection connection = Database.getConnection(true, 0)) {
                 Statement statement = connection.createStatement();
                 List<String> tableData = new ArrayList<>();
                 List<String> indexData = new ArrayList<>();
@@ -545,7 +542,6 @@ public class Database extends Queue {
                     initializeTables(prefix, statement);
                 }
                 statement.close();
-                connection.close();
             }
             catch (Exception e) {
                 e.printStackTrace();

--- a/src/main/java/net/coreprotect/database/lookup/BlockLookupAPI.java
+++ b/src/main/java/net/coreprotect/database/lookup/BlockLookupAPI.java
@@ -18,7 +18,7 @@ public class BlockLookupAPI {
     public static List<String[]> performLookup(Block block, int offset) {
         List<String[]> result = new ArrayList<>();
 
-        try {
+        try (Connection connection = Database.getConnection(false, 1000)) {
             if (block == null) {
                 return result;
             }
@@ -33,7 +33,6 @@ public class BlockLookupAPI {
                 checkTime = time - offset;
             }
 
-            Connection connection = Database.getConnection(false, 1000);
             if (connection == null) {
                 return result;
             }
@@ -62,7 +61,6 @@ public class BlockLookupAPI {
             }
             results.close();
             statement.close();
-            connection.close();
         }
         catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/net/coreprotect/listener/entity/HangingBreakByEntityListener.java
+++ b/src/main/java/net/coreprotect/listener/entity/HangingBreakByEntityListener.java
@@ -33,8 +33,7 @@ public final class HangingBreakByEntityListener extends Queue implements Listene
         class BasicThread implements Runnable {
             @Override
             public void run() {
-                try {
-                    Connection connection = Database.getConnection(true);
+                try (Connection connection = Database.getConnection(true)) {
                     if (connection != null) {
                         Statement statement = connection.createStatement();
                         String blockData = BlockLookup.performLookup(null, statement, block, player, 0, 1, 7);
@@ -49,7 +48,6 @@ public final class HangingBreakByEntityListener extends Queue implements Listene
                         }
 
                         statement.close();
-                        connection.close();
                     }
                     else {
                         Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.DATABASE_BUSY));

--- a/src/main/java/net/coreprotect/listener/player/PlayerInteractListener.java
+++ b/src/main/java/net/coreprotect/listener/player/PlayerInteractListener.java
@@ -87,24 +87,23 @@ public final class PlayerInteractListener extends Queue implements Listener {
             class BasicThread implements Runnable {
                 @Override
                 public void run() {
-                    try {
-                        if (ConfigHandler.converterRunning) {
-                            player.sendMessage(Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.UPGRADE_IN_PROGRESS));
+                    if (ConfigHandler.converterRunning) {
+                        player.sendMessage(Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.UPGRADE_IN_PROGRESS));
+                        return;
+                    }
+                    if (ConfigHandler.purgeRunning) {
+                        player.sendMessage(Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.PURGE_IN_PROGRESS));
+                        return;
+                    }
+                    if (ConfigHandler.lookupThrottle.get(player.getName()) != null) {
+                        Object[] lookupThrottle = ConfigHandler.lookupThrottle.get(player.getName());
+                        if ((boolean) lookupThrottle[0] || (System.currentTimeMillis() - (long) lookupThrottle[1]) < 100) {
+                            player.sendMessage(Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.DATABASE_BUSY));
                             return;
                         }
-                        if (ConfigHandler.purgeRunning) {
-                            player.sendMessage(Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.PURGE_IN_PROGRESS));
-                            return;
-                        }
-                        if (ConfigHandler.lookupThrottle.get(player.getName()) != null) {
-                            Object[] lookupThrottle = ConfigHandler.lookupThrottle.get(player.getName());
-                            if ((boolean) lookupThrottle[0] || (System.currentTimeMillis() - (long) lookupThrottle[1]) < 100) {
-                                player.sendMessage(Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.DATABASE_BUSY));
-                                return;
-                            }
-                        }
+                    }
 
-                        Connection connection = Database.getConnection(true);
+                    try (Connection connection = Database.getConnection(true)) {
                         if (connection != null) {
                             ConfigHandler.lookupThrottle.put(player.getName(), new Object[] { true, System.currentTimeMillis() });
                             Statement statement = connection.createStatement();
@@ -120,7 +119,6 @@ public final class PlayerInteractListener extends Queue implements Listener {
                             }
 
                             statement.close();
-                            connection.close();
                             ConfigHandler.lookupThrottle.put(player.getName(), new Object[] { false, System.currentTimeMillis() });
 
                             if (blockFinal instanceof Sign && player.getGameMode() != GameMode.CREATIVE) {
@@ -185,28 +183,27 @@ public final class PlayerInteractListener extends Queue implements Listener {
                         class BasicThread implements Runnable {
                             @Override
                             public void run() {
-                                try {
-                                    if (ConfigHandler.converterRunning) {
-                                        Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.UPGRADE_IN_PROGRESS));
+                                if (ConfigHandler.converterRunning) {
+                                    Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.UPGRADE_IN_PROGRESS));
+                                    return;
+                                }
+
+                                if (ConfigHandler.purgeRunning) {
+                                    Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.PURGE_IN_PROGRESS));
+                                    return;
+                                }
+
+                                if (ConfigHandler.lookupThrottle.get(player.getName()) != null) {
+                                    Object[] lookupThrottle = ConfigHandler.lookupThrottle.get(player.getName());
+                                    if ((boolean) lookupThrottle[0] || (System.currentTimeMillis() - (long) lookupThrottle[1]) < 100) {
+                                        Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.DATABASE_BUSY));
                                         return;
                                     }
+                                }
 
-                                    if (ConfigHandler.purgeRunning) {
-                                        Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.PURGE_IN_PROGRESS));
-                                        return;
-                                    }
+                                ConfigHandler.lookupThrottle.put(player.getName(), new Object[] { true, System.currentTimeMillis() });
 
-                                    if (ConfigHandler.lookupThrottle.get(player.getName()) != null) {
-                                        Object[] lookupThrottle = ConfigHandler.lookupThrottle.get(player.getName());
-                                        if ((boolean) lookupThrottle[0] || (System.currentTimeMillis() - (long) lookupThrottle[1]) < 100) {
-                                            Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.DATABASE_BUSY));
-                                            return;
-                                        }
-                                    }
-
-                                    ConfigHandler.lookupThrottle.put(player.getName(), new Object[] { true, System.currentTimeMillis() });
-
-                                    Connection connection = Database.getConnection(true);
+                                try (Connection connection = Database.getConnection(true)) {
                                     if (connection != null) {
                                         Statement statement = connection.createStatement();
                                         List<String> signData = SignMessageLookup.performLookup(null, statement, location, player, 1, 7);
@@ -225,7 +222,6 @@ public final class PlayerInteractListener extends Queue implements Listener {
                                         }
 
                                         statement.close();
-                                        connection.close();
                                     }
                                     else {
                                         Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.DATABASE_BUSY));
@@ -269,28 +265,27 @@ public final class PlayerInteractListener extends Queue implements Listener {
                         class BasicThread implements Runnable {
                             @Override
                             public void run() {
-                                try {
-                                    if (ConfigHandler.converterRunning) {
-                                        Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.UPGRADE_IN_PROGRESS));
-                                        return;
+                                if (ConfigHandler.converterRunning) {
+                                    Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.UPGRADE_IN_PROGRESS));
+                                    return;
+                                }
+
+                                if (ConfigHandler.purgeRunning) {
+                                    Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.PURGE_IN_PROGRESS));
+                                    return;
+                                }
+
+                                if (ConfigHandler.lookupThrottle.get(player.getName()) != null) {
+                                    Object[] lookupThrottle = ConfigHandler.lookupThrottle.get(player.getName());
+                                    if ((boolean) lookupThrottle[0] || (System.currentTimeMillis() - (long) lookupThrottle[1]) < 100) {
+                                       Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.DATABASE_BUSY));
+                                       return;
                                     }
+                                }
 
-                                    if (ConfigHandler.purgeRunning) {
-                                        Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.PURGE_IN_PROGRESS));
-                                        return;
-                                    }
+                                ConfigHandler.lookupThrottle.put(player.getName(), new Object[] { true, System.currentTimeMillis() });
 
-                                    if (ConfigHandler.lookupThrottle.get(player.getName()) != null) {
-                                        Object[] lookupThrottle = ConfigHandler.lookupThrottle.get(player.getName());
-                                        if ((boolean) lookupThrottle[0] || (System.currentTimeMillis() - (long) lookupThrottle[1]) < 100) {
-                                            Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.DATABASE_BUSY));
-                                            return;
-                                        }
-                                    }
-
-                                    ConfigHandler.lookupThrottle.put(player.getName(), new Object[] { true, System.currentTimeMillis() });
-
-                                    Connection connection = Database.getConnection(true);
+                                try (Connection connection = Database.getConnection(true)) {
                                     if (connection != null) {
                                         Statement statement = connection.createStatement();
                                         String blockData = ChestTransactionLookup.performLookup(null, statement, finalLocation, player, 1, 7, false);
@@ -305,7 +300,6 @@ public final class PlayerInteractListener extends Queue implements Listener {
                                         }
 
                                         statement.close();
-                                        connection.close();
                                     }
                                     else {
                                         Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.DATABASE_BUSY));
@@ -340,26 +334,25 @@ public final class PlayerInteractListener extends Queue implements Listener {
                         class BasicThread implements Runnable {
                             @Override
                             public void run() {
-                                try {
-                                    if (ConfigHandler.converterRunning) {
-                                        Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.UPGRADE_IN_PROGRESS));
+                                if (ConfigHandler.converterRunning) {
+                                    Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.UPGRADE_IN_PROGRESS));
+                                    return;
+                                }
+                                if (ConfigHandler.purgeRunning) {
+                                    Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.PURGE_IN_PROGRESS));
+                                    return;
+                                }
+                                if (ConfigHandler.lookupThrottle.get(player.getName()) != null) {
+                                    Object[] lookupThrottle = ConfigHandler.lookupThrottle.get(player.getName());
+                                    if ((boolean) lookupThrottle[0] || (System.currentTimeMillis() - (long) lookupThrottle[1]) < 100) {
+                                        Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.DATABASE_BUSY));
                                         return;
                                     }
-                                    if (ConfigHandler.purgeRunning) {
-                                        Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.PURGE_IN_PROGRESS));
-                                        return;
-                                    }
-                                    if (ConfigHandler.lookupThrottle.get(player.getName()) != null) {
-                                        Object[] lookupThrottle = ConfigHandler.lookupThrottle.get(player.getName());
-                                        if ((boolean) lookupThrottle[0] || (System.currentTimeMillis() - (long) lookupThrottle[1]) < 100) {
-                                            Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.DATABASE_BUSY));
-                                            return;
-                                        }
-                                    }
+                                }
 
-                                    ConfigHandler.lookupThrottle.put(player.getName(), new Object[] { true, System.currentTimeMillis() });
+                                ConfigHandler.lookupThrottle.put(player.getName(), new Object[] { true, System.currentTimeMillis() });
 
-                                    Connection connection = Database.getConnection(true);
+                                try (Connection connection = Database.getConnection(true)) {
                                     if (connection != null) {
                                         Statement statement = connection.createStatement();
                                         String blockData = InteractionLookup.performLookup(null, statement, finalInteractBlock, player, 0, 1, 7);
@@ -374,7 +367,6 @@ public final class PlayerInteractListener extends Queue implements Listener {
                                         }
 
                                         statement.close();
-                                        connection.close();
                                     }
                                     else {
                                         Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.DATABASE_BUSY));
@@ -421,28 +413,27 @@ public final class PlayerInteractListener extends Queue implements Listener {
                         class BasicThread implements Runnable {
                             @Override
                             public void run() {
-                                try {
-                                    if (ConfigHandler.converterRunning) {
-                                        Chat.sendMessage(finalPlayer, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.UPGRADE_IN_PROGRESS));
+                                if (ConfigHandler.converterRunning) {
+                                    Chat.sendMessage(finalPlayer, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.UPGRADE_IN_PROGRESS));
+                                    return;
+                                }
+
+                                if (ConfigHandler.purgeRunning) {
+                                    Chat.sendMessage(finalPlayer, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.PURGE_IN_PROGRESS));
+                                    return;
+                                }
+
+                                if (ConfigHandler.lookupThrottle.get(finalPlayer.getName()) != null) {
+                                    Object[] lookupThrottle = ConfigHandler.lookupThrottle.get(finalPlayer.getName());
+                                    if ((boolean) lookupThrottle[0] || (System.currentTimeMillis() - (long) lookupThrottle[1]) < 100) {
+                                        Chat.sendMessage(finalPlayer, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.DATABASE_BUSY));
                                         return;
                                     }
+                                }
 
-                                    if (ConfigHandler.purgeRunning) {
-                                        Chat.sendMessage(finalPlayer, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.PURGE_IN_PROGRESS));
-                                        return;
-                                    }
+                                ConfigHandler.lookupThrottle.put(finalPlayer.getName(), new Object[] { true, System.currentTimeMillis() });
 
-                                    if (ConfigHandler.lookupThrottle.get(finalPlayer.getName()) != null) {
-                                        Object[] lookupThrottle = ConfigHandler.lookupThrottle.get(finalPlayer.getName());
-                                        if ((boolean) lookupThrottle[0] || (System.currentTimeMillis() - (long) lookupThrottle[1]) < 100) {
-                                            Chat.sendMessage(finalPlayer, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.DATABASE_BUSY));
-                                            return;
-                                        }
-                                    }
-
-                                    ConfigHandler.lookupThrottle.put(finalPlayer.getName(), new Object[] { true, System.currentTimeMillis() });
-
-                                    Connection connection = Database.getConnection(true);
+                                try (Connection connection = Database.getConnection(true)) {
                                     if (connection != null) {
                                         Statement statement = connection.createStatement();
                                         if (finalBlock.getType().equals(Material.AIR) || finalBlock.getType().equals(Material.CAVE_AIR)) {
@@ -470,7 +461,6 @@ public final class PlayerInteractListener extends Queue implements Listener {
                                         }
 
                                         statement.close();
-                                        connection.close();
                                     }
                                     else {
                                         Chat.sendMessage(finalPlayer, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.DATABASE_BUSY));

--- a/src/main/java/net/coreprotect/patch/Patch.java
+++ b/src/main/java/net/coreprotect/patch/Patch.java
@@ -151,10 +151,9 @@ public class Patch {
         int result = -1;
         patching = true;
 
-        try {
+        try (Connection connection = Database.getConnection(true, 0)) {
             boolean patched = false;
             boolean allPatches = true;
-            Connection connection = Database.getConnection(true, 0);
             Statement statement = connection.createStatement();
             Integer[] newVersion = lastVersion;
 
@@ -221,7 +220,6 @@ public class Patch {
             }
 
             statement.close();
-            connection.close();
         }
         catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
Add HikariCP to support connection pooling for MySQL as discussed in #81. Default connection pool size is 10. We could add a configuration entry for it but 10 seems appropriate for any server size.

`com.zaxxer.HikariCP:4.0.3` is the latest version still supporting Java 8. It should be updated when CoreProtect requires Java 11 or newer.

HikariCP could also be utilized for SQLite (or any database), but the data source properties right now are MySQL Connector/J-specific.

`SET NAMES 'utf8mb4'` is unnecessary when the `characterEncoding=UTF-8` property is specified.

Tested on Paper 1.17.1 and MariaDB 10.5.