### PR TITLE
Make link clickable

### DIFF
--- a/src/main/java/net/coreprotect/CoreProtect.java
+++ b/src/main/java/net/coreprotect/CoreProtect.java
@@ -88,7 +88,7 @@ public final class CoreProtect extends JavaPlugin {
 
             Chat.console("--------------------");
             Chat.console(Phrase.build(Phrase.ENJOY_COREPROTECT, pluginDescription.getName()));
-            Chat.console(Phrase.build(Phrase.LINK_DISCORD, "www.coreprotect.net/discord/"));
+            Chat.console(Phrase.build(Phrase.LINK_DISCORD, "https://coreprotect.net/discord/"));
             Chat.console("--------------------");
 
             getServer().getScheduler().scheduleSyncDelayedTask(this, () -> {


### PR DESCRIPTION
So basically, this makes the link clickable in a console window (ptero or terminal for example) so it's easier for end users to be able to update CoreProtect/go to the Discord, rather than copying and pasting from console (it's even harder if console moves fast)
Summary: A really stupidly slight change that makes life slightly better :D