### PR TITLE
Improve the query time for /co lookup

### DIFF
--- a/src/main/java/net/coreprotect/database/Lookup.java
+++ b/src/main/java/net/coreprotect/database/Lookup.java
@@ -602,40 +602,6 @@ public class Lookup extends Queue {
                 queryOrder = "";
             }
 
-            if (Config.getGlobal().MYSQL) {
-                if (radius == null || users.length() > 0 || includeBlock.length() > 0 || includeEntity.length() > 0) {
-                    // index_mysql = "IGNORE INDEX(wid) ";
-                    if (users.length() > 0) {
-                        // index_mysql = "IGNORE INDEX(wid,type,action) ";
-                    }
-                }
-
-                if (queryTable.equals("block")) {
-                    if (includeBlock.length() > 0 || includeEntity.length() > 0) {
-                        index = "USE INDEX(type) ";
-                    }
-                    if (users.length() > 0) {
-                        index = "USE INDEX(user) ";
-                    }
-                    if ((radius != null || actionList.contains(5)) || (index.equals("") && restrictWorld)) {
-                        index = "USE INDEX(wid) ";
-                    }
-                }
-            }
-            else {
-                if (queryTable.equals("block")) {
-                    if (includeBlock.length() > 0 || includeEntity.length() > 0) {
-                        index = "INDEXED BY block_type_index ";
-                    }
-                    if (users.length() > 0) {
-                        index = "INDEXED BY block_user_index ";
-                    }
-                    if ((radius != null || actionList.contains(5)) || (index.equals("") && restrictWorld)) {
-                        index = "INDEXED BY block_index ";
-                    }
-                }
-            }
-
             boolean itemLookup = (actionList.contains(4) && actionList.contains(11));
             if (lookup && actionList.size() == 0) {
                 if (!count) {


### PR DESCRIPTION
I experienced an unusually high latency for `/co lookup`. 
I found that instead of using multiple indexes, only one is being used at a time.
In my pull request, I removed the manual mapping of indexes so that sqlite and mysql automatically use the relevant indexes.

I stopped the time for a large request and these are my results: 
Command: `/co lookup user:josxha time:100d radius:5000`
My `block` table has about 3.4 million entries.

database | build | time
------------- | ------------- | -------------
sqlite | without fix | 12.09s
sqlite | with fix | 5.32s
mysql | without fix | 123.83s!
mysql | with fix | 8.42s

