### PR TITLE
Show item data when hovering the mouse over the Item

### DIFF
--- a/docs/api/networking.md
+++ b/docs/api/networking.md
@@ -22,20 +22,35 @@ Sends data from the database.
 
 * Channel: `coreprotect:data`
 
-| Type: `Int` | 1                      | 2                      | 3                  | 4                  |
-|-------------|------------------------|------------------------|--------------------|--------------------|
-|             | Time: `long`           | Time: `long`           | Time: `long`       | Time: `long`       |
-|             | Phrase selector: `UTF` | Phrase selector: `UTF` | Result User: `UTF` | Result User: `UTF` |
-|             | Result User: `UTF`     | Result User: `UTF`     | Message: `UTF`     | Target: `UTF`      |
-|             | Target: `UTF`          | Amount: `Int`          | Sign: `Boolean`    |                    |
-|             | Amount: `Int`          | X: `Int`               | X: `Int`           |                    |
-|             | X: `Int`               | Y: `Int`               | Y: `Int`           |                    |
-|             | Y: `Int`               | Z: `Int`               | Z: `Int`           |                    |
-|             | Z: `Int`               | World name: `UTF`      | World name: `UTF`  |                    |
-|             | World name: `UTF`      |                        |                    |                    |
-|             | Rolledback: `Boolean`  |                        |                    |                    |
-|             | isContainer: `Boolean` |                        |                    |                    |
-|             | Added: `Boolean`       |                        |                    |                    |
+| Type: `Int` | 1                           | 2                      | 3                  | 4                  |
+|-------------|-----------------------------|------------------------|--------------------|--------------------|
+|             | Time: `long`                | Time: `long`           | Time: `long`       | Time: `long`       |
+|             | Phrase selector: `UTF`      | Phrase selector: `UTF` | Result User: `UTF` | Result User: `UTF` |
+|             | Result User: `UTF`          | Result User: `UTF`     | Message: `UTF`     | Target: `UTF`      |
+|             | Target: `UTF`               | Amount: `Int`          | Sign: `Boolean`    |                    |
+|             | Amount: `Int`               | X: `Int`               | X: `Int`           |                    |
+|             | X: `Int`                    | Y: `Int`               | Y: `Int`           |                    |
+|             | Y: `Int`                    | Z: `Int`               | Z: `Int`           |                    |
+|             | Z: `Int`                    | World name: `UTF`      | World name: `UTF`  |                    |
+|             | World name: `UTF`           |                        |                    |                    |
+|             | Rolledback: `Boolean`       |                        |                    |                    |
+|             | isContainer: `Boolean`      |                        |                    |                    |
+|             | Added: `Boolean`            |                        |                    |                    |
+|             | Additional Info: `Addition` |                        |                    |                    |
+
+Type Addition:
+If amount addition info is 0, it won't sent any Additional info Items
+
+| Info                                       | Required |
+|--------------------------------------------|----------|
+| Additional Info Hashmap size `Int`         | True     |
+| Additional Info Items, more info see below |          |
+The following info you will get per item:
+
+| Info                             |
+|----------------------------------|
+| Additional Info Item Key `UTF`   |
+| Additional Info Item Value `UTF` |
 
 Example (Fabric):
 ```
@@ -54,6 +69,37 @@ String worldName = dis.readUTF();
 boolean rolledback = dis.readBoolean();
 boolean isContainer = dis.readBoolean();
 boolean added = dis.readBoolean();
+int additionalItemSize = dis.readInt();
+```
+
+Example with additional Info (Fabric):
+```
+ByteArrayInputStream in = new ByteArrayInputStream(buf.getWrittenBytes());
+DataInputStream dis = new DataInputStream(in);
+HashMap<String, Object> addition = new HashMap<>();
+int type = dis.readInt();
+long time = dis.readLong();
+String selector = dis.readUTF();
+String  resultUser = dis.readUTF();
+String target = dis.readUTF();
+int amount = dis.readInt();
+int x = dis.readInt();
+int y = dis.readInt();
+int z = dis.readInt();
+String worldName = dis.readUTF();
+boolean rolledback = dis.readBoolean();
+boolean isContainer = dis.readBoolean();
+boolean added = dis.readBoolean();
+int additionalItemSize = dis.readInt();
+if (additionalItemSize != 0)
+{
+   for (int i = 0; i <= additionalItemSize; i++)
+   {
+      String key = dis.readUTF();
+      String value = dis.readUTF();
+      addition.put(key, value);
+   }
+}
 ```
 
 ### Handshake Packet

--- a/src/main/java/net/coreprotect/command/LookupCommand.java
+++ b/src/main/java/net/coreprotect/command/LookupCommand.java
@@ -1,5 +1,6 @@
 package net.coreprotect.command;
 
+import java.io.ByteArrayInputStream;
 import java.sql.Connection;
 import java.sql.Statement;
 import java.text.NumberFormat;
@@ -7,6 +8,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.HashMap;
+import java.util.Base64;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -16,6 +19,7 @@ import org.bukkit.block.BlockState;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 
@@ -40,6 +44,9 @@ import net.coreprotect.utility.Chat;
 import net.coreprotect.utility.ChatMessage;
 import net.coreprotect.utility.Color;
 import net.coreprotect.utility.Util;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.util.io.BukkitObjectInputStream;
 
 public class LookupCommand {
     protected static void runCommand(CommandSender player, Command command, boolean permission, String[] args) {
@@ -969,6 +976,10 @@ public class LookupCommand {
                                                     int wid = Integer.parseInt(data[9]);
                                                     int amount = Integer.parseInt(data[10]);
                                                     String tag = Color.WHITE + "-";
+                                                    byte[] metadata = null;
+                                                    if (data[11] != null) {
+                                                        metadata = Base64.getDecoder().decode(data[11]);
+                                                    }
 
                                                     String timeago = Util.getTimeSince(Integer.parseInt(time), unixtimestamp, true);
                                                     int timeLength = 50 + (Util.getTimeSince(Integer.parseInt(time), unixtimestamp, false).replaceAll("[^0-9]", "").length() * 6);
@@ -1040,8 +1051,12 @@ public class LookupCommand {
                                                             action = "a:container";
                                                         }
 
-                                                        Chat.sendComponent(player2, timeago + " " + tag + " " + Phrase.build(phrase, Color.DARK_AQUA + rbd + dplayer + Color.WHITE + rbd, "x" + amount, Color.DARK_AQUA + rbd + dname + Color.WHITE, selector));
-                                                        PluginChannelListener.getInstance().sendData(player2, Integer.parseInt(time), phrase, selector, dplayer, dname, (tag.contains("+") ? 1 : -1), x, y, z, wid, rbd, action.contains("container"), tag.contains("+"));
+
+                                                        String formattedName = Util.formatItemMetaPopup(Color.DARK_AQUA + rbd + dname + Color.WHITE, Util.getType(Integer.valueOf(dtype)), metadata);
+                                                        HashMap<String, String> additionalData = Util.convertItemMeta(Util.getType(Integer.valueOf(dtype)), metadata);
+
+                                                        Chat.sendComponent(player2, timeago + " " + tag + " " + Phrase.build(phrase, Color.DARK_AQUA + rbd + dplayer + Color.WHITE + rbd, "x" + amount, formattedName, selector));
+                                                        PluginChannelListener.getInstance().sendData(player2, Integer.parseInt(time), phrase, selector, dplayer, dname, (tag.contains("+") ? 1 : -1), x, y, z, wid, rbd, action.contains("container"), tag.contains("+"), additionalData);
                                                     }
                                                     else {
                                                         if (daction == 2 || daction == 3) {

--- a/src/main/java/net/coreprotect/config/Config.java
+++ b/src/main/java/net/coreprotect/config/Config.java
@@ -86,7 +86,7 @@ public class Config extends Language {
     public boolean PLAYER_SESSIONS;
     public boolean USERNAME_CHANGES;
     public boolean WORLDEDIT;
-    public boolean show_custom_model_data;
+    public boolean SHOW_CUSTOM_MODEL_DATA;
     public int MYSQL_PORT;
     public int DEFAULT_RADIUS;
     public int MAX_RADIUS;
@@ -241,7 +241,7 @@ public class Config extends Language {
         this.PLAYER_SESSIONS = this.getBoolean("player-sessions");
         this.USERNAME_CHANGES = this.getBoolean("username-changes");
         this.WORLDEDIT = this.getBoolean("worldedit");
-        this.show_custom_model_data = this.getBoolean("show-custom-model-data");
+        this.SHOW_CUSTOM_MODEL_DATA = this.getBoolean("show-custom-model-data");
     }
 
     public static void init() throws IOException {

--- a/src/main/java/net/coreprotect/config/Config.java
+++ b/src/main/java/net/coreprotect/config/Config.java
@@ -86,6 +86,7 @@ public class Config extends Language {
     public boolean PLAYER_SESSIONS;
     public boolean USERNAME_CHANGES;
     public boolean WORLDEDIT;
+    public boolean show_custom_model_data;
     public int MYSQL_PORT;
     public int DEFAULT_RADIUS;
     public int MAX_RADIUS;
@@ -138,6 +139,7 @@ public class Config extends Language {
         DEFAULT_VALUES.put("player-sessions", "true");
         DEFAULT_VALUES.put("username-changes", "true");
         DEFAULT_VALUES.put("worldedit", "true");
+        DEFAULT_VALUES.put("show-custom-model-data", "false");
 
         HEADERS.put("donation-key", new String[] { "# CoreProtect is donationware. For more information, visit our project page." });
         HEADERS.put("use-mysql", new String[] { "# MySQL is optional and not required.", "# If you prefer to use MySQL, enable the following and fill out the fields." });
@@ -180,6 +182,7 @@ public class Config extends Language {
         HEADERS.put("player-sessions", new String[] { "# Logs the logins and logouts of players." });
         HEADERS.put("username-changes", new String[] { "# Logs when a player changes their Minecraft username." });
         HEADERS.put("worldedit", new String[] { "# Logs changes made via the plugin \"WorldEdit\" if it's in use on your server." });
+        HEADERS.put("show-custom-model-data", new String[] { "# Show custom model data of block when hovering mouse over it." });
     }
 
     private void readValues() {
@@ -238,6 +241,7 @@ public class Config extends Language {
         this.PLAYER_SESSIONS = this.getBoolean("player-sessions");
         this.USERNAME_CHANGES = this.getBoolean("username-changes");
         this.WORLDEDIT = this.getBoolean("worldedit");
+        this.show_custom_model_data = this.getBoolean("show-custom-model-data");
     }
 
     public static void init() throws IOException {

--- a/src/main/java/net/coreprotect/database/Lookup.java
+++ b/src/main/java/net/coreprotect/database/Lookup.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Base64;
 
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -54,6 +55,9 @@ public class Lookup extends Queue {
                         else {
                             results[newId] = (String) map[i];
                         }
+                    }
+                    else if (i == 12 && map[i] instanceof byte[]) {
+                        results[newId] = Base64.getEncoder().encodeToString((byte[]) map[i]);
                     }
                     else if (i == 13 && map[i] instanceof Byte[]) {
                         results[newId] = Util.byteDataToString((byte[]) map[i], (int) map[6]);

--- a/src/main/java/net/coreprotect/database/lookup/ChestTransactionLookup.java
+++ b/src/main/java/net/coreprotect/database/lookup/ChestTransactionLookup.java
@@ -129,9 +129,10 @@ public class ChestTransactionLookup {
                     target = target.split(":")[1];
                 }
 
+                String displayName = "";
+                Integer customModelData = null;
+                String popupText = "";
                 if (resultMetadata != null) {
-                    String popupText = "";
-
                     BukkitObjectInputStream metaObjectStream = new BukkitObjectInputStream(new ByteArrayInputStream(resultMetadata));
                     Object metaList = metaObjectStream.readObject();
 
@@ -145,14 +146,14 @@ public class ChestTransactionLookup {
                         }
                         popupText += Color.WHITE + "customModelData" + Color.GREY + ": " + Color.DARK_AQUA + itemMeta.getCustomModelData();
                     }
-
-                    if (!popupText.equals("")) {
-                        target = Chat.COMPONENT_TAG_OPEN + Chat.COMPONENT_POPUP + "|" + popupText + "|" + Color.DARK_AQUA + rbFormat + target + Chat.COMPONENT_TAG_CLOSE;
-                    }
                 }
 
+                PluginChannelListener.getInstance().sendData(commandSender, resultTime, Phrase.LOOKUP_CONTAINER, selector, resultUser, target, resultAmount, x, y, z, worldId, rbFormat, true, tag.contains("+"), displayName, customModelData);
+                if (!popupText.equals("")) {
+                    target = Chat.COMPONENT_TAG_OPEN + Chat.COMPONENT_POPUP + "|" + popupText + "|" + Color.DARK_AQUA + rbFormat + target + Chat.COMPONENT_TAG_CLOSE;
+                }
                 resultBuilder.append(timeAgo + " " + tag + " ").append(Phrase.build(Phrase.LOOKUP_CONTAINER, Color.DARK_AQUA + rbFormat + resultUser + Color.WHITE + rbFormat, "x" + resultAmount, Color.DARK_AQUA + rbFormat + target + Color.WHITE, selector)).append("\n");
-                PluginChannelListener.getInstance().sendData(commandSender, resultTime, Phrase.LOOKUP_CONTAINER, selector, resultUser, target, resultAmount, x, y, z, worldId, rbFormat, true, tag.contains("+"));
+
             }
             result = resultBuilder.toString();
             results.close();

--- a/src/main/java/net/coreprotect/database/lookup/ChestTransactionLookup.java
+++ b/src/main/java/net/coreprotect/database/lookup/ChestTransactionLookup.java
@@ -137,7 +137,7 @@ public class ChestTransactionLookup {
                     }
                     if (itemMeta.hasCustomModelData()) {
                         if (!popupText.equals("")) {
-                            popupText += Color.GREY + " ";
+                            popupText += "\\n";
                         }
                         popupText += Color.WHITE + "customModelData" + Color.GREY + ": " + Color.DARK_AQUA + itemMeta.getCustomModelData();
                     }

--- a/src/main/java/net/coreprotect/database/lookup/ChestTransactionLookup.java
+++ b/src/main/java/net/coreprotect/database/lookup/ChestTransactionLookup.java
@@ -165,6 +165,7 @@ public class ChestTransactionLookup {
                             popupText += Color.WHITE + "\\n - " + Color.DARK_AQUA + name + " " + Color.GREY + itemMeta.getEnchantLevel(enchant);
                             additionalData.put("enchantments", additionalData.get("enchantments") + name + "-" + itemMeta.getEnchantLevel(enchant) + "|");
                         }
+                        additionalData.put("enchantments", additionalData.get("enchantments").substring(0, additionalData.get("enchantments").length() - 1));
                     }
                 }
 

--- a/src/main/java/net/coreprotect/database/lookup/ChestTransactionLookup.java
+++ b/src/main/java/net/coreprotect/database/lookup/ChestTransactionLookup.java
@@ -130,51 +130,12 @@ public class ChestTransactionLookup {
                     target = target.split(":")[1];
                 }
 
-                String popupText = "";
-                HashMap<String, String> additionalData = new HashMap<>();
-                if (resultMetadata != null) {
-                    BukkitObjectInputStream metaObjectStream = new BukkitObjectInputStream(new ByteArrayInputStream(resultMetadata));
-                    Object metaList = metaObjectStream.readObject();
-
-                    ItemMeta itemMeta = Util.deserializeItemMeta(new ItemStack(Util.getType(resultType)).getItemMeta().getClass(), ((List<List<Map<String, Object>>>) metaList).get(0).get(0));
-                    if (itemMeta.hasDisplayName()) {
-                        String displayName = itemMeta.getDisplayName();
-                        popupText = Color.WHITE + "customName" + Color.GREY + ": " + Color.DARK_AQUA + "\"" + displayName + Color.DARK_AQUA + "\"";
-                        additionalData.put("customName", displayName);
-                    }
-                    if (itemMeta.hasCustomModelData() && Config.getGlobal().SHOW_CUSTOM_MODEL_DATA) {
-                        if (!popupText.equals("")) {
-                            popupText += "\\n";
-                        }
-                        int customModelData = itemMeta.getCustomModelData();
-                        popupText += Color.WHITE + "customModelData" + Color.GREY + ": " + Color.DARK_AQUA + customModelData;
-                        additionalData.put("customModelData", String.valueOf(customModelData));
-                    }
-                    if (itemMeta.hasEnchants()) {
-                        if (!popupText.equals("")) {
-                            popupText += "\\n";
-                        }
-                        additionalData.put("enchantments", "");
-                        popupText += Color.WHITE + "enchants" + Color.GREY + ":";
-                        for (Enchantment enchant : itemMeta.getEnchants().keySet()) {
-                            String name = enchant.getKey().toString();
-                            if (name.startsWith("minecraft:")) {
-                                name = name.split(":")[1];
-                            }
-
-                            popupText += Color.WHITE + "\\n - " + Color.DARK_AQUA + name + " " + Color.GREY + itemMeta.getEnchantLevel(enchant);
-                            additionalData.put("enchantments", additionalData.get("enchantments") + name + "-" + itemMeta.getEnchantLevel(enchant) + "|");
-                        }
-                        additionalData.put("enchantments", additionalData.get("enchantments").substring(0, additionalData.get("enchantments").length() - 1));
-                    }
-                }
+                String formattedName = Util.formatItemMetaPopup(Color.DARK_AQUA + rbFormat + target + Color.WHITE, Util.getType(Integer.valueOf(resultType)), resultMetadata);
+                formattedName = formattedName.replace("\n", "\\n"); // To protect newlines inside of the popup
+                HashMap<String, String> additionalData = Util.convertItemMeta(Util.getType(Integer.valueOf(resultType)), resultMetadata);
 
                 PluginChannelListener.getInstance().sendData(commandSender, resultTime, Phrase.LOOKUP_CONTAINER, selector, resultUser, target, resultAmount, x, y, z, worldId, rbFormat, true, tag.contains("+"), additionalData);
-                if (!popupText.equals("")) {
-                    popupText = popupText.replace("|", "\\|"); // if the text has a pipe then it would break the popup
-                    target = Chat.COMPONENT_TAG_OPEN + Chat.COMPONENT_POPUP + "|" + popupText + "|" + Color.DARK_AQUA + rbFormat + target + Chat.COMPONENT_TAG_CLOSE;
-                }
-                resultBuilder.append(timeAgo + " " + tag + " ").append(Phrase.build(Phrase.LOOKUP_CONTAINER, Color.DARK_AQUA + rbFormat + resultUser + Color.WHITE + rbFormat, "x" + resultAmount, Color.DARK_AQUA + rbFormat + target + Color.WHITE, selector)).append("\n");
+                resultBuilder.append(timeAgo + " " + tag + " ").append(Phrase.build(Phrase.LOOKUP_CONTAINER, Color.DARK_AQUA + rbFormat + resultUser + Color.WHITE + rbFormat, "x" + resultAmount, formattedName, selector)).append("\n");
             }
             result = resultBuilder.toString();
             results.close();

--- a/src/main/java/net/coreprotect/database/lookup/ChestTransactionLookup.java
+++ b/src/main/java/net/coreprotect/database/lookup/ChestTransactionLookup.java
@@ -1,27 +1,30 @@
 package net.coreprotect.database.lookup;
 
-import net.coreprotect.config.Config;
-import net.coreprotect.config.ConfigHandler;
-import net.coreprotect.database.statement.UserStatement;
-import net.coreprotect.language.Phrase;
-import net.coreprotect.language.Selector;
-import net.coreprotect.listener.channel.PluginChannelListener;
-import net.coreprotect.utility.Chat;
-import net.coreprotect.utility.Color;
-import net.coreprotect.utility.Util;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.command.CommandSender;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.util.io.BukkitObjectInputStream;
-
-import java.io.ByteArrayInputStream;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.command.CommandSender;
+
+import net.coreprotect.config.ConfigHandler;
+import net.coreprotect.database.statement.UserStatement;
+import net.coreprotect.language.Phrase;
+import net.coreprotect.language.Selector;
+import net.coreprotect.listener.channel.PluginChannelListener;
+
+import net.coreprotect.utility.Chat;
+import net.coreprotect.utility.Color;
+import net.coreprotect.utility.Util;
+
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.util.io.BukkitObjectInputStream;
+
+import java.io.ByteArrayInputStream;
 
 public class ChestTransactionLookup {
 

--- a/src/main/java/net/coreprotect/database/lookup/ChestTransactionLookup.java
+++ b/src/main/java/net/coreprotect/database/lookup/ChestTransactionLookup.java
@@ -154,6 +154,7 @@ public class ChestTransactionLookup {
                         if (!popupText.equals("")) {
                             popupText += "\\n";
                         }
+                        additionalData.put("enchantments", "");
                         popupText += Color.WHITE + "enchants" + Color.GREY + ":";
                         for (Enchantment enchant : itemMeta.getEnchants().keySet()) {
                             String name = enchant.getKey().toString();
@@ -162,6 +163,7 @@ public class ChestTransactionLookup {
                             }
 
                             popupText += Color.WHITE + "\\n - " + Color.DARK_AQUA + name + " " + Color.GREY + itemMeta.getEnchantLevel(enchant);
+                            additionalData.put("enchantments", additionalData.get("enchantments") + name + "-" + itemMeta.getEnchantLevel(enchant) + "|");
                         }
                     }
                 }

--- a/src/main/java/net/coreprotect/database/lookup/ChestTransactionLookup.java
+++ b/src/main/java/net/coreprotect/database/lookup/ChestTransactionLookup.java
@@ -10,6 +10,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
 
+import net.coreprotect.config.Config;
 import net.coreprotect.config.ConfigHandler;
 import net.coreprotect.database.statement.UserStatement;
 import net.coreprotect.language.Phrase;
@@ -138,7 +139,7 @@ public class ChestTransactionLookup {
                     if (itemMeta.hasDisplayName()) {
                         popupText = Color.WHITE + "customName" + Color.GREY + ": " + Color.DARK_AQUA + "\"" + itemMeta.getDisplayName() + "\"";
                     }
-                    if (itemMeta.hasCustomModelData()) {
+                    if (itemMeta.hasCustomModelData() && Config.getGlobal().SHOW_CUSTOM_MODEL_DATA) {
                         if (!popupText.equals("")) {
                             popupText += "\\n";
                         }

--- a/src/main/java/net/coreprotect/database/lookup/ChestTransactionLookup.java
+++ b/src/main/java/net/coreprotect/database/lookup/ChestTransactionLookup.java
@@ -1,30 +1,20 @@
 package net.coreprotect.database.lookup;
 
-import java.io.ByteArrayInputStream;
-import java.sql.ResultSet;
-import java.sql.Statement;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.command.CommandSender;
-import org.bukkit.enchantments.Enchantment;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.util.io.BukkitObjectInputStream;
-
-import net.coreprotect.config.Config;
 import net.coreprotect.config.ConfigHandler;
 import net.coreprotect.database.statement.UserStatement;
 import net.coreprotect.language.Phrase;
 import net.coreprotect.language.Selector;
 import net.coreprotect.listener.channel.PluginChannelListener;
-import net.coreprotect.utility.Chat;
 import net.coreprotect.utility.Color;
 import net.coreprotect.utility.Util;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.command.CommandSender;
+
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Locale;
 
 
 

--- a/src/main/java/net/coreprotect/database/lookup/ChestTransactionLookup.java
+++ b/src/main/java/net/coreprotect/database/lookup/ChestTransactionLookup.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.util.io.BukkitObjectInputStream;
@@ -148,6 +149,20 @@ public class ChestTransactionLookup {
                         int customModelData = itemMeta.getCustomModelData();
                         popupText += Color.WHITE + "customModelData" + Color.GREY + ": " + Color.DARK_AQUA + customModelData;
                         additionalData.put("customModelData", String.valueOf(customModelData));
+                    }
+                    if (itemMeta.hasEnchants()) {
+                        if (!popupText.equals("")) {
+                            popupText += "\\n";
+                        }
+                        popupText += Color.WHITE + "enchants" + Color.GREY + ":";
+                        for (Enchantment enchant : itemMeta.getEnchants().keySet()) {
+                            String name = enchant.getKey().toString();
+                            if (name.startsWith("minecraft:")) {
+                                name = name.split(":")[1];
+                            }
+
+                            popupText += Color.WHITE + "\\n - " + Color.DARK_AQUA + name + " " + Color.GREY + itemMeta.getEnchantLevel(enchant);
+                        }
                     }
                 }
 

--- a/src/main/java/net/coreprotect/database/lookup/ChestTransactionLookup.java
+++ b/src/main/java/net/coreprotect/database/lookup/ChestTransactionLookup.java
@@ -138,7 +138,7 @@ public class ChestTransactionLookup {
                     ItemMeta itemMeta = Util.deserializeItemMeta(new ItemStack(Util.getType(resultType)).getItemMeta().getClass(), ((List<List<Map<String, Object>>>) metaList).get(0).get(0));
                     if (itemMeta.hasDisplayName()) {
                         String displayName = itemMeta.getDisplayName();
-                        popupText = Color.WHITE + "customName" + Color.GREY + ": " + Color.DARK_AQUA + "\"" + displayName + "\"";
+                        popupText = Color.WHITE + "customName" + Color.GREY + ": " + Color.DARK_AQUA + "\"" + displayName + Color.DARK_AQUA + "\"";
                         additionalData.put("customName", displayName);
                     }
                     if (itemMeta.hasCustomModelData() && Config.getGlobal().SHOW_CUSTOM_MODEL_DATA) {

--- a/src/main/java/net/coreprotect/database/lookup/ChestTransactionLookup.java
+++ b/src/main/java/net/coreprotect/database/lookup/ChestTransactionLookup.java
@@ -151,7 +151,6 @@ public class ChestTransactionLookup {
                     }
                 }
 
-                //                                                                                                                                          Keep these in case no hover and target is default    \/              \/
                 resultBuilder.append(timeAgo + " " + tag + " ").append(Phrase.build(Phrase.LOOKUP_CONTAINER, Color.DARK_AQUA + rbFormat + resultUser + Color.WHITE + rbFormat, "x" + resultAmount, Color.DARK_AQUA + rbFormat + target + Color.WHITE, selector)).append("\n");
                 PluginChannelListener.getInstance().sendData(commandSender, resultTime, Phrase.LOOKUP_CONTAINER, selector, resultUser, target, resultAmount, x, y, z, worldId, rbFormat, true, tag.contains("+"));
             }

--- a/src/main/java/net/coreprotect/database/lookup/ChestTransactionLookup.java
+++ b/src/main/java/net/coreprotect/database/lookup/ChestTransactionLookup.java
@@ -171,6 +171,7 @@ public class ChestTransactionLookup {
 
                 PluginChannelListener.getInstance().sendData(commandSender, resultTime, Phrase.LOOKUP_CONTAINER, selector, resultUser, target, resultAmount, x, y, z, worldId, rbFormat, true, tag.contains("+"), additionalData);
                 if (!popupText.equals("")) {
+                    popupText = popupText.replace("|", "\\|"); // if the text has a pipe then it would break the popup
                     target = Chat.COMPONENT_TAG_OPEN + Chat.COMPONENT_POPUP + "|" + popupText + "|" + Color.DARK_AQUA + rbFormat + target + Chat.COMPONENT_TAG_CLOSE;
                 }
                 resultBuilder.append(timeAgo + " " + tag + " ").append(Phrase.build(Phrase.LOOKUP_CONTAINER, Color.DARK_AQUA + rbFormat + resultUser + Color.WHITE + rbFormat, "x" + resultAmount, Color.DARK_AQUA + rbFormat + target + Color.WHITE, selector)).append("\n");

--- a/src/main/java/net/coreprotect/listener/channel/PluginChannelListener.java
+++ b/src/main/java/net/coreprotect/listener/channel/PluginChannelListener.java
@@ -3,7 +3,8 @@ package net.coreprotect.listener.channel;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
 
 import org.bukkit.command.CommandSender;
@@ -32,10 +33,10 @@ public class PluginChannelListener implements Listener {
     }
 
     public void sendData(CommandSender commandSender, long timeAgo, Phrase phrase, String selector, String resultUser, String target, int amount, int x, int y, int z, int worldId, String rbFormat, boolean isContainer, boolean added) throws IOException {
-        sendData(commandSender, timeAgo, phrase, selector ,resultUser, target,amount, x, y, z, worldId, rbFormat, isContainer, added, null, null);
+        sendData(commandSender, timeAgo, phrase, selector ,resultUser, target,amount, x, y, z, worldId, rbFormat, isContainer, added, null);
     }
 
-    public void sendData(CommandSender commandSender, long timeAgo, Phrase phrase, String selector, String resultUser, String target, int amount, int x, int y, int z, int worldId, String rbFormat, boolean isContainer, boolean added, String displayName, Integer customModelData) throws IOException {
+    public void sendData(CommandSender commandSender, long timeAgo, Phrase phrase, String selector, String resultUser, String target, int amount, int x, int y, int z, int worldId, String rbFormat, boolean isContainer, boolean added, HashMap<String, String> additional) throws IOException {
         if (!PluginChannelHandshakeListener.getInstance().isPluginChannelPlayer(commandSender)) {
             return;
         }
@@ -58,8 +59,15 @@ public class PluginChannelListener implements Listener {
         msgOut.writeBoolean(!rbFormat.isEmpty());
         msgOut.writeBoolean(isContainer);
         msgOut.writeBoolean(added);
-        msgOut.writeUTF(displayName);
-        msgOut.writeInt(customModelData);
+        msgOut.writeInt(additional == null ? 0 : additional.size());
+        if (additional != null)
+        {
+            for (Map.Entry<String, String> additionalItem : additional.entrySet())
+            {
+                msgOut.writeUTF(additionalItem.getKey());
+                msgOut.writeUTF(additionalItem.getValue());
+            }
+        }
         if (Config.getGlobal().NETWORK_DEBUG) {
             Chat.console(String.valueOf(timeAgo * 1000));
             Chat.console(phraseSelector);
@@ -73,6 +81,15 @@ public class PluginChannelListener implements Listener {
             Chat.console(String.valueOf(!rbFormat.isEmpty()));
             Chat.console(String.valueOf(isContainer));
             Chat.console(String.valueOf(added));
+            Chat.console(String.valueOf(additional == null ? 0 : additional.size()));
+            if (additional != null)
+            {
+                for (Map.Entry<String, String> additionalItem : additional.entrySet())
+                {
+                    msgOut.writeUTF(additionalItem.getKey());
+                    msgOut.writeUTF(additionalItem.getValue());
+                }
+            }
             Chat.console("");
         }
 
@@ -188,8 +205,9 @@ public class PluginChannelListener implements Listener {
         String rbFormat = "test";
         String message = "This is a test";
         boolean sign = true;
-        String displayName = "testing";
-        Integer customModelData = 4;
+        HashMap<String, String> additional = new HashMap<>();
+        additional.put("displayName", "testing");
+        additional.put("customModelData", String.valueOf(4));
 
         switch (type) {
             case "2":
@@ -202,7 +220,7 @@ public class PluginChannelListener implements Listener {
                 sendUsernameData(commandSender, timeAgo, resultUser, "Arne");
                 break;
             default:
-                sendData(commandSender, timeAgo, Phrase.LOOKUP_CONTAINER, selector, resultUser, "clay_ball", amount, x, y, z, worldId, rbFormat, false, true, displayName, customModelData);
+                sendData(commandSender, timeAgo, Phrase.LOOKUP_CONTAINER, selector, resultUser, "clay_ball", amount, x, y, z, worldId, rbFormat, false, true, additional);
                 break;
         }
 

--- a/src/main/java/net/coreprotect/listener/channel/PluginChannelListener.java
+++ b/src/main/java/net/coreprotect/listener/channel/PluginChannelListener.java
@@ -3,6 +3,7 @@ package net.coreprotect.listener.channel;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Random;
 
 import org.bukkit.command.CommandSender;
@@ -31,6 +32,10 @@ public class PluginChannelListener implements Listener {
     }
 
     public void sendData(CommandSender commandSender, long timeAgo, Phrase phrase, String selector, String resultUser, String target, int amount, int x, int y, int z, int worldId, String rbFormat, boolean isContainer, boolean added) throws IOException {
+        sendData(commandSender, timeAgo, phrase, selector ,resultUser, target,amount, x, y, z, worldId, rbFormat, isContainer, added, null, null);
+    }
+
+    public void sendData(CommandSender commandSender, long timeAgo, Phrase phrase, String selector, String resultUser, String target, int amount, int x, int y, int z, int worldId, String rbFormat, boolean isContainer, boolean added, String displayName, Integer customModelData) throws IOException {
         if (!PluginChannelHandshakeListener.getInstance().isPluginChannelPlayer(commandSender)) {
             return;
         }
@@ -53,6 +58,8 @@ public class PluginChannelListener implements Listener {
         msgOut.writeBoolean(!rbFormat.isEmpty());
         msgOut.writeBoolean(isContainer);
         msgOut.writeBoolean(added);
+        msgOut.writeUTF(displayName);
+        msgOut.writeInt(customModelData);
         if (Config.getGlobal().NETWORK_DEBUG) {
             Chat.console(String.valueOf(timeAgo * 1000));
             Chat.console(phraseSelector);
@@ -181,6 +188,8 @@ public class PluginChannelListener implements Listener {
         String rbFormat = "test";
         String message = "This is a test";
         boolean sign = true;
+        String displayName = "testing";
+        Integer customModelData = 4;
 
         switch (type) {
             case "2":
@@ -193,7 +202,7 @@ public class PluginChannelListener implements Listener {
                 sendUsernameData(commandSender, timeAgo, resultUser, "Arne");
                 break;
             default:
-                sendData(commandSender, timeAgo, Phrase.LOOKUP_CONTAINER, selector, resultUser, "clay_ball", amount, x, y, z, worldId, rbFormat, false, true);
+                sendData(commandSender, timeAgo, Phrase.LOOKUP_CONTAINER, selector, resultUser, "clay_ball", amount, x, y, z, worldId, rbFormat, false, true, displayName, customModelData);
                 break;
         }
 

--- a/src/main/java/net/coreprotect/listener/channel/PluginChannelListener.java
+++ b/src/main/java/net/coreprotect/listener/channel/PluginChannelListener.java
@@ -87,7 +87,7 @@ public class PluginChannelListener implements Listener {
                 for (Map.Entry<String, String> additionalItem : additional.entrySet())
                 {
                     Chat.console(additionalItem.getKey());
-                    msgOut.writeUTF(additionalItem.getValue());
+                    Chat.console(additionalItem.getValue());
                 }
             }
             Chat.console("");

--- a/src/main/java/net/coreprotect/listener/channel/PluginChannelListener.java
+++ b/src/main/java/net/coreprotect/listener/channel/PluginChannelListener.java
@@ -86,7 +86,7 @@ public class PluginChannelListener implements Listener {
             {
                 for (Map.Entry<String, String> additionalItem : additional.entrySet())
                 {
-                    msgOut.writeUTF(additionalItem.getKey());
+                    Chat.console(additionalItem.getKey());
                     msgOut.writeUTF(additionalItem.getValue());
                 }
             }

--- a/src/main/java/net/coreprotect/listener/player/PlayerInteractListener.java
+++ b/src/main/java/net/coreprotect/listener/player/PlayerInteractListener.java
@@ -307,10 +307,12 @@ public final class PlayerInteractListener extends Queue implements Listener {
 
                                         if (blockData.contains("\n")) {
                                             for (String splitData : blockData.split("\n")) {
+                                                splitData = splitData.replace("\\n", "\n");
                                                 Chat.sendComponent(player, splitData);
                                             }
                                         }
                                         else {
+                                            blockData = blockData.replace("\\n", "\n");
                                             Chat.sendComponent(player, blockData);
                                         }
 

--- a/src/main/java/net/coreprotect/spigot/SpigotHandler.java
+++ b/src/main/java/net/coreprotect/spigot/SpigotHandler.java
@@ -37,7 +37,7 @@ public class SpigotHandler extends SpigotAdapter implements SpigotInterface {
                     addBuilder(message, builder);
                 }
 
-                String[] data = value.split("\\|", 3);
+                String[] data = value.split("(?<=[^\\\\])\\|", 3);
                 if (data[0].equals(Chat.COMPONENT_COMMAND)) {
                     TextComponent component = new TextComponent(TextComponent.fromLegacyText(data[2]));
                     component.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, data[1]));

--- a/src/main/java/net/coreprotect/spigot/Spigot_v1_16.java
+++ b/src/main/java/net/coreprotect/spigot/Spigot_v1_16.java
@@ -18,8 +18,8 @@ public class Spigot_v1_16 extends SpigotHandler implements SpigotInterface {
     public void addHoverComponent(Object message, String[] data) {
         try {
             if (Config.getGlobal().HOVER_EVENTS) {
-                TextComponent component = new TextComponent(TextComponent.fromLegacyText(data[2]));
-                component.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(TextComponent.fromLegacyText(data[1]))));
+                TextComponent component = new TextComponent(TextComponent.fromLegacyText(data[2].replace("\\|", "|")));
+                component.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(TextComponent.fromLegacyText(data[1].replace("\\|", "|")))));
                 ((TextComponent) message).addExtra(component);
             }
             else {


### PR DESCRIPTION
When you hover your mouse over an item when inspecting a chest, it will show the custom name of that item and also the customModelData (Only if set to true in config).
![image](https://user-images.githubusercontent.com/37347905/168463485-92bc1ffa-d625-4d1d-80a3-b9e325ab6e80.png)
![image](https://user-images.githubusercontent.com/37347905/168463535-62a835ce-0deb-4a96-95e3-193d7ed9a1c6.png)
![image](https://user-images.githubusercontent.com/37347905/168463546-8685aa69-bcc9-425c-8de0-02d54738e248.png)
If an item does not have any customModelData or does not have a custom name then it will not be shown, if they have neither then no hover dialogue opens!
I did have to modify [PlayerInteractListener.java](https://github.com/GreenJon902/CoreProtect/blob/2242ba8f45ea1c41a0c4125a2c0c73484547bfaf/src/main/java/net/coreprotect/listener/player/PlayerInteractListener.java#L310) to add newlines that don't get sent as their own messages by replacing `"\\n"` with `"\n"` after the string with `"\n"` was split up.