### PR TITLE
Make version comparisons by long - Support WorldEdit 7.2.11 Beta 1

### DIFF
--- a/src/main/java/net/coreprotect/utility/Util.java
+++ b/src/main/java/net/coreprotect/utility/Util.java
@@ -1019,7 +1019,7 @@ public class Util extends Queue {
                 if (version.contains("-beta-")) {
                     version = version.split(";")[0];
                     version = version.split("-beta-")[1];
-                    int value = Integer.parseInt(version.replaceAll("[^0-9]", ""));
+                    long value = Long.parseLong(version.replaceAll("[^0-9]", ""));
                     if (value < 6) {
                         validVersion = false;
                     }
@@ -1033,7 +1033,7 @@ public class Util extends Queue {
                     }
 
                     if (version.contains("-")) {
-                        int value = Integer.parseInt(((version.split("-"))[0]).replaceAll("[^0-9]", ""));
+                        long value = Long.parseLong(((version.split("-"))[0]).replaceAll("[^0-9]", ""));
                         if (value > 0 && value < 4268) {
                             validVersion = false;
                         }


### PR DESCRIPTION
This PR fixes the error: https://pastes.dev/YPyYZAHkT9 when loading WorldEdit 7.2.11 Beta 1 by making the version checks into a `long` instead of `int`.

Tested on Paper 1.19 with Worldedit 7.2.11 Beta 1