### PR TITLE
style: fix UnnecessaryToStringCall in multiple files

### DIFF
--- a/src/main/java/net/coreprotect/consumer/process/ContainerTransactionProcess.java
+++ b/src/main/java/net/coreprotect/consumer/process/ContainerTransactionProcess.java
@@ -21,7 +21,7 @@ class ContainerTransactionProcess {
             Map<Integer, Object> inventories = Consumer.consumerInventories.get(processId);
             if (inventories.get(id) != null) {
                 Object inventory = inventories.get(id);
-                String transactingChestId = location.getWorld().getUID().toString() + "." + location.getBlockX() + "." + location.getBlockY() + "." + location.getBlockZ();
+                String transactingChestId = location.getWorld().getUID() + "." + location.getBlockX() + "." + location.getBlockY() + "." + location.getBlockZ();
                 String loggingChestId = user.toLowerCase(Locale.ROOT) + "." + location.getBlockX() + "." + location.getBlockY() + "." + location.getBlockZ();
                 if (ConfigHandler.loggingChest.get(loggingChestId) != null) {
                     int current_chest = ConfigHandler.loggingChest.get(loggingChestId);

--- a/src/main/java/net/coreprotect/database/logger/ContainerLogger.java
+++ b/src/main/java/net/coreprotect/database/logger/ContainerLogger.java
@@ -74,7 +74,7 @@ public class ContainerLogger extends Queue {
                 }
             }
             else {
-                String transactingChestId = location.getWorld().getUID().toString() + "." + location.getBlockX() + "." + location.getBlockY() + "." + location.getBlockZ();
+                String transactingChestId = location.getWorld().getUID() + "." + location.getBlockX() + "." + location.getBlockY() + "." + location.getBlockZ();
                 if (ConfigHandler.transactingChest.get(transactingChestId) != null) {
                     List<Object> list = Collections.synchronizedList(new ArrayList<>(ConfigHandler.transactingChest.get(transactingChestId)));
                     if (list.size() > 0) {

--- a/src/main/java/net/coreprotect/database/lookup/SignMessageLookup.java
+++ b/src/main/java/net/coreprotect/database/lookup/SignMessageLookup.java
@@ -109,7 +109,7 @@ public class SignMessageLookup {
                     result.add(new StringBuilder(Color.WHITE + "----- " + Color.DARK_AQUA + Phrase.build(Phrase.SIGN_HEADER) + Color.WHITE + " ----- " + Util.getCoordinates(command, worldId, x, y, z, false, false) + "").toString());
                 }
                 found = true;
-                result.add(timeAgo + Color.WHITE + " - " + Color.DARK_AQUA + resultUser + ": " + Color.WHITE + "\n" + message.toString() + Color.WHITE);
+                result.add(timeAgo + Color.WHITE + " - " + Color.DARK_AQUA + resultUser + ": " + Color.WHITE + "\n" + message  + Color.WHITE);
                 PluginChannelListener.getInstance().sendMessageData(commandSender, resultTime, resultUser, message.toString(), true, x, y, z, worldId);
             }
             results.close();

--- a/src/main/java/net/coreprotect/database/lookup/SignMessageLookup.java
+++ b/src/main/java/net/coreprotect/database/lookup/SignMessageLookup.java
@@ -109,7 +109,7 @@ public class SignMessageLookup {
                     result.add(new StringBuilder(Color.WHITE + "----- " + Color.DARK_AQUA + Phrase.build(Phrase.SIGN_HEADER) + Color.WHITE + " ----- " + Util.getCoordinates(command, worldId, x, y, z, false, false) + "").toString());
                 }
                 found = true;
-                result.add(timeAgo + Color.WHITE + " - " + Color.DARK_AQUA + resultUser + ": " + Color.WHITE + "\n" + message  + Color.WHITE);
+                result.add(timeAgo + Color.WHITE + " - " + Color.DARK_AQUA + resultUser + ": " + Color.WHITE + "\n" + message + Color.WHITE);
                 PluginChannelListener.getInstance().sendMessageData(commandSender, resultTime, resultUser, message.toString(), true, x, y, z, worldId);
             }
             results.close();

--- a/src/main/java/net/coreprotect/listener/player/ArmorStandManipulateListener.java
+++ b/src/main/java/net/coreprotect/listener/player/ArmorStandManipulateListener.java
@@ -138,7 +138,7 @@ public final class ArmorStandManipulateListener extends Queue implements Listene
         int y = standLocation.getBlockY();
         int z = standLocation.getBlockZ();
 
-        String transactingChestId = standLocation.getWorld().getUID().toString() + "." + x + "." + y + "." + z;
+        String transactingChestId = standLocation.getWorld().getUID() + "." + x + "." + y + "." + z;
         String loggingChestId = player.getName().toLowerCase(Locale.ROOT) + "." + x + "." + y + "." + z;
         int chestId = Queue.getChestId(loggingChestId);
         if (chestId > 0) {

--- a/src/main/java/net/coreprotect/listener/player/HopperPullListener.java
+++ b/src/main/java/net/coreprotect/listener/player/HopperPullListener.java
@@ -105,7 +105,7 @@ public final class HopperPullListener {
                 }
 
                 if (!hopperTransactions) {
-                    List<Object> list = ConfigHandler.transactingChest.get(location.getWorld().getUID().toString() + "." + location.getBlockX() + "." + location.getBlockY() + "." + location.getBlockZ());
+                    List<Object> list = ConfigHandler.transactingChest.get(location.getWorld().getUID() + "." + location.getBlockX() + "." + location.getBlockY() + "." + location.getBlockZ());
                     if (list != null) {
                         list.add(movedItem);
                     }
@@ -113,7 +113,7 @@ public final class HopperPullListener {
                 }
 
                 Location destinationLocation = destinationHolder.getInventory().getLocation();
-                List<Object> list = ConfigHandler.transactingChest.get(destinationLocation.getWorld().getUID().toString() + "." + destinationLocation.getBlockX() + "." + destinationLocation.getBlockY() + "." + destinationLocation.getBlockZ());
+                List<Object> list = ConfigHandler.transactingChest.get(destinationLocation.getWorld().getUID() + "." + destinationLocation.getBlockX() + "." + destinationLocation.getBlockY() + "." + destinationLocation.getBlockZ());
                 if (list != null) {
                     list.add(new ItemStack[] { null, movedItem });
                 }

--- a/src/main/java/net/coreprotect/listener/player/HopperPushListener.java
+++ b/src/main/java/net/coreprotect/listener/player/HopperPushListener.java
@@ -78,7 +78,7 @@ public final class HopperPushListener {
                     return;
                 }
 
-                List<Object> list = ConfigHandler.transactingChest.get(location.getWorld().getUID().toString() + "." + location.getBlockX() + "." + location.getBlockY() + "." + location.getBlockZ());
+                List<Object> list = ConfigHandler.transactingChest.get(location.getWorld().getUID() + "." + location.getBlockX() + "." + location.getBlockY() + "." + location.getBlockZ());
                 if (list != null) {
                     list.add(movedItem);
                 }

--- a/src/main/java/net/coreprotect/listener/player/InventoryChangeListener.java
+++ b/src/main/java/net/coreprotect/listener/player/InventoryChangeListener.java
@@ -110,7 +110,7 @@ public final class InventoryChangeListener extends Queue implements Listener {
                     int y = playerLocation.getBlockY();
                     int z = playerLocation.getBlockZ();
 
-                    String transactingChestId = playerLocation.getWorld().getUID().toString() + "." + x + "." + y + "." + z;
+                    String transactingChestId = playerLocation.getWorld().getUID() + "." + x + "." + y + "." + z;
                     String loggingChestId = user.toLowerCase(Locale.ROOT) + "." + x + "." + y + "." + z;
                     for (String loggingChestIdViewer : ConfigHandler.oldContainer.keySet()) {
                         if (loggingChestIdViewer.equals(loggingChestId) || !loggingChestIdViewer.endsWith("." + x + "." + y + "." + z)) {
@@ -346,7 +346,7 @@ public final class InventoryChangeListener extends Queue implements Listener {
             return;
         }
 
-        List<Object> list = ConfigHandler.transactingChest.get(location.getWorld().getUID().toString() + "." + location.getBlockX() + "." + location.getBlockY() + "." + location.getBlockZ());
+        List<Object> list = ConfigHandler.transactingChest.get(location.getWorld().getUID() + "." + location.getBlockX() + "." + location.getBlockY() + "." + location.getBlockZ());
         if (list == null) {
             return;
         }

--- a/src/main/java/net/coreprotect/listener/player/PlayerInteractEntityListener.java
+++ b/src/main/java/net/coreprotect/listener/player/PlayerInteractEntityListener.java
@@ -84,7 +84,7 @@ public final class PlayerInteractEntityListener extends Queue implements Listene
         int y = frameLocation.getBlockY();
         int z = frameLocation.getBlockZ();
 
-        String transactingChestId = frameLocation.getWorld().getUID().toString() + "." + x + "." + y + "." + z;
+        String transactingChestId = frameLocation.getWorld().getUID() + "." + x + "." + y + "." + z;
         String loggingChestId = user.toLowerCase(Locale.ROOT) + "." + x + "." + y + "." + z;
         int chestId = Queue.getChestId(loggingChestId);
         if (chestId > 0) {

--- a/src/main/java/net/coreprotect/utility/Util.java
+++ b/src/main/java/net/coreprotect/utility/Util.java
@@ -127,7 +127,7 @@ public class Util extends Queue {
         message.append("|/" + command + " teleport wid:" + worldId + " " + (x + 0.50) + " " + y + " " + (z + 0.50) + "|");
 
         // chat output
-        message.append(Color.GREY + (italic ? Color.ITALIC : "") + "(x" + x + "/y" + y + "/z" + z + worldDisplay  + ")");
+        message.append(Color.GREY + (italic ? Color.ITALIC : "") + "(x" + x + "/y" + y + "/z" + z + worldDisplay + ")");
 
         return message.append(Chat.COMPONENT_TAG_CLOSE).toString();
     }
@@ -259,7 +259,7 @@ public class Util extends Queue {
             Date logDate = new Date(resultTime * 1000L);
             String formattedTimestamp = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z").format(logDate);
 
-            return Chat.COMPONENT_TAG_OPEN + Chat.COMPONENT_POPUP + "|" + Color.GREY + formattedTimestamp + "|" + Color.GREY + message  + Chat.COMPONENT_TAG_CLOSE;
+            return Chat.COMPONENT_TAG_OPEN + Chat.COMPONENT_POPUP + "|" + Color.GREY + formattedTimestamp + "|" + Color.GREY + message + Chat.COMPONENT_TAG_CLOSE;
         }
 
         return message.toString();

--- a/src/main/java/net/coreprotect/utility/Util.java
+++ b/src/main/java/net/coreprotect/utility/Util.java
@@ -127,7 +127,7 @@ public class Util extends Queue {
         message.append("|/" + command + " teleport wid:" + worldId + " " + (x + 0.50) + " " + y + " " + (z + 0.50) + "|");
 
         // chat output
-        message.append(Color.GREY + (italic ? Color.ITALIC : "") + "(x" + x + "/y" + y + "/z" + z + worldDisplay.toString() + ")");
+        message.append(Color.GREY + (italic ? Color.ITALIC : "") + "(x" + x + "/y" + y + "/z" + z + worldDisplay  + ")");
 
         return message.append(Chat.COMPONENT_TAG_CLOSE).toString();
     }
@@ -259,7 +259,7 @@ public class Util extends Queue {
             Date logDate = new Date(resultTime * 1000L);
             String formattedTimestamp = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z").format(logDate);
 
-            return Chat.COMPONENT_TAG_OPEN + Chat.COMPONENT_POPUP + "|" + Color.GREY + formattedTimestamp + "|" + Color.GREY + message.toString() + Chat.COMPONENT_TAG_CLOSE;
+            return Chat.COMPONENT_TAG_OPEN + Chat.COMPONENT_POPUP + "|" + Color.GREY + formattedTimestamp + "|" + Color.GREY + message  + Chat.COMPONENT_TAG_CLOSE;
         }
 
         return message.toString();


### PR DESCRIPTION
Hi @SirYwell showed me this outstanding plugin and I saw there are some issues in your code base. This PR removes some no needed `toString` calls. I kept the withespace diffs minimal for this PR. 
# Repairing Code Style Issues
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
# Repairing Code Style Issues
* UnnecessaryToStringCall (12)