### PR TITLE
Add hover component on Spigot 1.15

### DIFF
--- a/src/main/java/net/coreprotect/spigot/SpigotHandler.java
+++ b/src/main/java/net/coreprotect/spigot/SpigotHandler.java
@@ -2,6 +2,8 @@ package net.coreprotect.spigot;
 
 import java.util.regex.Matcher;
 
+import net.coreprotect.config.Config;
+import net.md_5.bungee.api.chat.HoverEvent;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 
@@ -17,7 +19,19 @@ public class SpigotHandler extends SpigotAdapter implements SpigotInterface {
 
     @Override
     public void addHoverComponent(Object message, String[] data) {
-        ((TextComponent) message).addExtra(data[2]);
+        try {
+            if (Config.getGlobal().HOVER_EVENTS) {
+                TextComponent component = new TextComponent(TextComponent.fromLegacyText(data[2]));
+                component.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText(data[1])));
+                ((TextComponent) message).addExtra(component);
+            }
+            else {
+                super.addHoverComponent(message, data);
+            }
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     @Override


### PR DESCRIPTION
Originally, hover components are only used on Spigot 1.16+.
This PR adds hover components on Spigot 1.15.

The method body of `addHoverComponent` is basically a copy from `Spigot_v1_16.java` except for the 2nd parameter of HoverEvent, because `net.md_5.bungee.api.chat.hover.content.Text` does not exist on Spigot 1.15.x.