### PR TITLE
The way Item stacks get merged can cause an incredibly long runtime 

### DIFF
--- a/src/main/java/net/coreprotect/utility/Util.java
+++ b/src/main/java/net/coreprotect/utility/Util.java
@@ -457,16 +457,20 @@ public class Util extends Queue {
         try {
             int c1 = 0;
             for (ItemStack o1 : items) {
-                int c2 = 0;
-                for (ItemStack o2 : items) {
-                    if (o1 != null && o2 != null && c2 > c1 && o1.isSimilar(o2) && !Util.isAir(o1.getType())) { // Ignores amount
-                        int namount = o1.getAmount() + o2.getAmount();
-                        o1.setAmount(namount);
-                        o2.setAmount(0);
+                if (o1 != null) {
+                    if (o1.getAmount() != 0) {
+                        int c2 = 0;
+                        for (ItemStack o2 : items) {
+                            if (o2 != null && c2 > c1 && o1.isSimilar(o2) && !Util.isAir(o1.getType())) { // Ignores amount
+                                int namount = o1.getAmount() + o2.getAmount();
+                                o1.setAmount(namount);
+                                o2.setAmount(0);
+                            }
+                            c2++;
+                        }
                     }
-                    c2++;
                 }
-                c1++;
+            c1++;
             }
         }
         catch (Exception e) {


### PR DESCRIPTION
If there is a large amount of times. this can take hours or days if the ItemStack array is large enough. This doesn’t happen during regular gameplay. But it can be caused by crafting continuously with a mod like Itemscroller. Like this the main Consumer while loop gets stuck in the merge. (as it causes 100k+ stacks to be processed) This causes an indefinite (depending on how long you crafted) halt of all database pushes. This can not only render these mods basically unusable, but it also generates a memory leek (as the que is stacked up) and also prevents logging till the merge is done. which, not only prevents proper restarts, but can also lose data when forcefully restarted.