### PR TITLE
fix(enable at 1_12_2): channel name

### DIFF
--- a/src/main/java/net/coreprotect/listener/channel/PluginChannelHandshakeListener.java
+++ b/src/main/java/net/coreprotect/listener/channel/PluginChannelHandshakeListener.java
@@ -24,7 +24,7 @@ import net.coreprotect.utility.Chat;
 
 public class PluginChannelHandshakeListener implements PluginMessageListener, Listener {
 
-    public static final String pluginChannel = "coreprotect:handshake";
+    public static final String pluginChannel = "cp:handshake";
     private final int networkingProtocolVersion = 1;
     private final Set<UUID> pluginChannelPlayers;
     private static PluginChannelHandshakeListener instance;

--- a/src/main/java/net/coreprotect/listener/channel/PluginChannelListener.java
+++ b/src/main/java/net/coreprotect/listener/channel/PluginChannelListener.java
@@ -19,7 +19,7 @@ import net.coreprotect.utility.Util;
 
 public class PluginChannelListener implements Listener {
 
-    public static final String pluginChannel = "coreprotect:data";
+    public static final String pluginChannel = "cp:data";
     private static PluginChannelListener instance;
 
     public PluginChannelListener() {


### PR DESCRIPTION
It's a fix for this problem:
`[Server thread/WARN]: org.bukkit.plugin.messaging.ChannelNameTooLongException: Attempted to send a Plugin Message to a channel that was too large. The maximum length a channel may be is 20 chars (attempted 21 - 'coreprotect:handshake.`