### PR TITLE
Make MySQL maximumPoolSize configurable

### DIFF
--- a/src/main/java/net/coreprotect/config/Config.java
+++ b/src/main/java/net/coreprotect/config/Config.java
@@ -41,6 +41,7 @@ public class Config extends Language {
     public String MYSQL_DATABASE;
     public String MYSQL_USERNAME;
     public String MYSQL_PASSWORD;
+    public int MYSQL_MAXIMUM_POOL_SIZE;
     public String LANGUAGE;
     public boolean ENABLE_AWE;
     public boolean DISABLE_WAL;
@@ -101,6 +102,7 @@ public class Config extends Language {
         DEFAULT_VALUES.put("mysql-database", "database");
         DEFAULT_VALUES.put("mysql-username", "root");
         DEFAULT_VALUES.put("mysql-password", "");
+        DEFAULT_VALUES.put("mysql-maximum-pool-size", "10");
         DEFAULT_VALUES.put("language", "en");
         DEFAULT_VALUES.put("check-updates", "true");
         DEFAULT_VALUES.put("api-enabled", "true");
@@ -203,6 +205,7 @@ public class Config extends Language {
         this.MYSQL_DATABASE = this.getString("mysql-database");
         this.MYSQL_USERNAME = this.getString("mysql-username");
         this.MYSQL_PASSWORD = this.getString("mysql-password");
+        this.MYSQL_MAXIMUM_POOL_SIZE = this.getInt("mysql-maximum-pool-size");
         this.LANGUAGE = this.getString("language");
         this.CHECK_UPDATES = this.getBoolean("check-updates");
         this.API_ENABLED = this.getBoolean("api-enabled");

--- a/src/main/java/net/coreprotect/config/Config.java
+++ b/src/main/java/net/coreprotect/config/Config.java
@@ -41,7 +41,6 @@ public class Config extends Language {
     public String MYSQL_DATABASE;
     public String MYSQL_USERNAME;
     public String MYSQL_PASSWORD;
-    public int MYSQL_MAXIMUM_POOL_SIZE;
     public String LANGUAGE;
     public boolean ENABLE_AWE;
     public boolean DISABLE_WAL;
@@ -89,6 +88,7 @@ public class Config extends Language {
     public boolean PLAYER_SESSIONS;
     public boolean USERNAME_CHANGES;
     public boolean WORLDEDIT;
+    public int MYSQL_MAXIMUM_POOL_SIZE;
     public int MYSQL_PORT;
     public int DEFAULT_RADIUS;
     public int MAX_RADIUS;
@@ -102,7 +102,6 @@ public class Config extends Language {
         DEFAULT_VALUES.put("mysql-database", "database");
         DEFAULT_VALUES.put("mysql-username", "root");
         DEFAULT_VALUES.put("mysql-password", "");
-        DEFAULT_VALUES.put("mysql-maximum-pool-size", "10");
         DEFAULT_VALUES.put("language", "en");
         DEFAULT_VALUES.put("check-updates", "true");
         DEFAULT_VALUES.put("api-enabled", "true");
@@ -205,7 +204,7 @@ public class Config extends Language {
         this.MYSQL_DATABASE = this.getString("mysql-database");
         this.MYSQL_USERNAME = this.getString("mysql-username");
         this.MYSQL_PASSWORD = this.getString("mysql-password");
-        this.MYSQL_MAXIMUM_POOL_SIZE = this.getInt("mysql-maximum-pool-size");
+        this.MYSQL_MAXIMUM_POOL_SIZE = this.getInt("mysql-maximum-pool-size", 10);
         this.LANGUAGE = this.getString("language");
         this.CHECK_UPDATES = this.getBoolean("check-updates");
         this.API_ENABLED = this.getBoolean("api-enabled");

--- a/src/main/java/net/coreprotect/config/ConfigHandler.java
+++ b/src/main/java/net/coreprotect/config/ConfigHandler.java
@@ -52,6 +52,8 @@ public class ConfigHandler extends Queue {
     public static String username = "root";
     public static String password = "";
     public static String prefix = "co_";
+    public static int maximumPoolSize = 10;
+
     public static HikariDataSource hikariDataSource = null;
     public static final boolean isSpigot = Util.isSpigot();
     public static final boolean isPaper = Util.isPaper();
@@ -174,6 +176,7 @@ public class ConfigHandler extends Queue {
             ConfigHandler.database = Config.getGlobal().MYSQL_DATABASE;
             ConfigHandler.username = Config.getGlobal().MYSQL_USERNAME;
             ConfigHandler.password = Config.getGlobal().MYSQL_PASSWORD;
+            ConfigHandler.maximumPoolSize = Config.getGlobal().MYSQL_MAXIMUM_POOL_SIZE;
             ConfigHandler.prefix = Config.getGlobal().PREFIX;
 
             ConfigHandler.loadBlacklist(); // Load the blacklist file if it exists.
@@ -230,6 +233,7 @@ public class ConfigHandler extends Queue {
             config.setJdbcUrl("jdbc:mysql://" + ConfigHandler.host + ":" + ConfigHandler.port + "/" + ConfigHandler.database);
             config.setUsername(ConfigHandler.username);
             config.setPassword(ConfigHandler.password);
+            config.setMaximumPoolSize(ConfigHandler.maximumPoolSize);
             config.setMaxLifetime(60000);
             config.addDataSourceProperty("characterEncoding", "UTF-8");
             config.addDataSourceProperty("connectionTimeout", "10000");


### PR DESCRIPTION
This change adds an entry to the config file where one can set the maximum pool size of the MySQL/MariaDB database connection. The default is set to 10, which is the default when not setting it at all anyway, so existing installations should see no change.

Allowing this value to be configurable can be useful if, for example, many Minecraft (or other) server instances are connecting to a database server which has a limited amount of connections it allows. On the other hand, increasing this value could help when connecting to a powerful database server with a highly loaded Minecraft server.