### PR TITLE
Add method override for FAWE paste logging

### DIFF
--- a/src/main/java/net/coreprotect/worldedit/CoreProtectLogger.java
+++ b/src/main/java/net/coreprotect/worldedit/CoreProtectLogger.java
@@ -56,4 +56,8 @@ public class CoreProtectLogger extends AbstractDelegateExtent {
         return false;
     }
 
+    public <T extends BlockStateHolder<T>> boolean setBlock(int x, int y, int z, T block) throws WorldEditException {
+        return setBlock(BlockVector3.at(x,y,z), block);
+    }
+
 }


### PR DESCRIPTION
The only reason CoreProtect does not log FAWE pastes is because FAWE uses a slightly different method they added:
`public <T extends BlockStateHolder<T>> boolean setBlock(int x, int y, int z, T block) throws WorldEditException`

by adding an override for this method in the CoreProtectLogger, CoreProtect can now intercept the blocks to log them.

Fixes #234 

![image](https://github.com/PlayPro/CoreProtect/assets/28172529/0f5ab01f-6149-4ef7-b8ee-1595ffa23241)
