### PR TITLE
Do not tab complete vanished players

### DIFF
--- a/src/main/java/net/coreprotect/command/TabHandler.java
+++ b/src/main/java/net/coreprotect/command/TabHandler.java
@@ -6,6 +6,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
@@ -18,6 +19,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.StringUtil;
 
 import net.coreprotect.config.ConfigHandler;
+import net.coreprotect.utility.Util;
 
 public class TabHandler implements TabCompleter {
 
@@ -170,7 +172,7 @@ public class TabHandler implements TabCompleter {
                     arg = split[1];
                 }
 
-                List<String> completions = Bukkit.getOnlinePlayers().stream().map(Player::getName).collect(Collectors.toList());
+                List<String> completions = Bukkit.getOnlinePlayers().stream().filter(Predicate.not(Util::isVanished)).map(Player::getName).collect(Collectors.toList());
                 for (int index = 0; index < completions.size(); index++) {
                     completions.set(index, filter + completions.get(index));
                 }
@@ -338,7 +340,7 @@ public class TabHandler implements TabCompleter {
                 }
                 else if ((sender.hasPermission("coreprotect.lookup") && (argument0.equals("l") || argument0.equals("lookup"))) || (sender.hasPermission("coreprotect.rollback") && (argument0.equals("rollback") || argument0.equals("rb") || argument0.equals("ro"))) || (sender.hasPermission("coreprotect.restore") && (argument0.equals("restore") || argument0.equals("rs") || argument0.equals("re")))) {
                     List<String> completions = new ArrayList<>(filterParams(true, argument0, argument1, hasUser, hasAction, hasInclude, hasExclude, hasRadius, hasTime, hasContainer, hasCount, hasPreview, pageLookup, validContainer));
-                    completions.addAll(Bukkit.getOnlinePlayers().stream().filter(player -> player.getName().toLowerCase(Locale.ROOT).startsWith(argument1)).map(Player::getName).collect(Collectors.toList()));
+                    completions.addAll(Bukkit.getOnlinePlayers().stream().filter(Predicate.not(Util::isVanished)).filter(player -> player.getName().toLowerCase(Locale.ROOT).startsWith(argument1)).map(Player::getName).collect(Collectors.toList()));
                     return StringUtil.copyPartialMatches(argument1, completions, new ArrayList<>(completions.size()));
                 }
             }

--- a/src/main/java/net/coreprotect/utility/Util.java
+++ b/src/main/java/net/coreprotect/utility/Util.java
@@ -47,6 +47,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.metadata.MetadataValue;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.util.io.BukkitObjectOutputStream;
 
@@ -1640,4 +1641,10 @@ public class Util extends Queue {
         return ((isFront && (data == 1 || data == 3)) || (!isFront && (data == 2 || data == 3)));
     }
 
+    public static boolean isVanished(Player player) {
+        for (MetadataValue meta : player.getMetadata("vanished")) {
+            if (meta.asBoolean()) return true;
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
Using a command with the user: argument will have vanished players in the tab complete list, exposing them as being vanished. This PR adds the method from https://www.spigotmc.org/resources/supervanish-be-invisible.1331/ for detecting vanished players in a way that does not require any dependencies and is used by many popular vanish plugins, and filters the user list for `/co lookup` and `/co rollback` to not include vanished players