### PR TITLE
Add clause "implements Cancellable"

### DIFF
--- a/src/main/java/net/coreprotect/event/CoreProtectPreLogEvent.java
+++ b/src/main/java/net/coreprotect/event/CoreProtectPreLogEvent.java
@@ -1,9 +1,10 @@
 package net.coreprotect.event;
 
+import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
-public class CoreProtectPreLogEvent extends Event {
+public class CoreProtectPreLogEvent extends Event implements Cancellable {
 
     private static final HandlerList handlers = new HandlerList();
     private boolean cancelled = false;
@@ -18,10 +19,12 @@ public class CoreProtectPreLogEvent extends Event {
         return user;
     }
 
+    @Override
     public boolean isCancelled() {
         return cancelled;
     }
 
+    @Override
     public void setCancelled(boolean cancel) {
         this.cancelled = cancel;
     }


### PR DESCRIPTION
I add a little code to make net.coreprotect.event.CoreProtectPreLogEvent implement the interface org.bukkit.event.Cancellable.
This is useful for other plugins listening to abstract cancellable events.