### PR TITLE
Fix CoreProtect API hasPlaced() and hasRemoved() (#434)

### DIFF
--- a/src/main/java/net/coreprotect/CoreProtectAPI.java
+++ b/src/main/java/net/coreprotect/CoreProtectAPI.java
@@ -191,8 +191,8 @@ public class CoreProtectAPI extends Queue {
         boolean match = false;
 
         if (Config.getGlobal().API_ENABLED) {
-            long timestamp = System.currentTimeMillis() / 1000L;
-            long offsetTime = timestamp - offset;
+            long timestamp = System.currentTimeMillis();
+            long offsetTime = timestamp - offset * 1000L;
             List<String[]> check = blockLookup(block, time);
 
             for (String[] value : check) {
@@ -212,8 +212,8 @@ public class CoreProtectAPI extends Queue {
         boolean match = false;
 
         if (Config.getGlobal().API_ENABLED) {
-            long timestamp = System.currentTimeMillis() / 1000L;
-            long offsetTime = timestamp - offset;
+            long timestamp = System.currentTimeMillis();
+            long offsetTime = timestamp - offset * 1000L;
             List<String[]> check = blockLookup(block, time);
 
             for (String[] value : check) {


### PR DESCRIPTION
Bug fix of the issue #434.
The methods used to compare the timestamp of block data as milliseconds and the offset time as seconds.
I made them compare the values as milliseconds.