### PR TITLE
Add CoreProtectPreCommandLogEvent event

### DIFF
--- a/docs/api/version/v9.md
+++ b/docs/api/version/v9.md
@@ -127,6 +127,15 @@ Fired when a CoreProtect logger is about to log an action. Cancellable.
 | User | The name of the user under which this action will be logged. | Yes |
 | Cancelled | If cancelled, the action won't be logged to the database. | Yes |
 
+#### CoreProtectPreCommandLogEvent
+
+Fired when a CoreProtect logger is about to log a command. Cancellable.
+
+| Property | Description | Muteable |
+| --- | --- | --- |
+| User | The name of the user under which this action will be logged. | Yes |
+| Command | The command to be logged | Yes |
+| Cancelled | If cancelled, the action won't be logged to the database. | Yes |
 ---
 
 ### Method Usage

--- a/src/main/java/net/coreprotect/database/logger/CommandLogger.java
+++ b/src/main/java/net/coreprotect/database/logger/CommandLogger.java
@@ -3,6 +3,7 @@ package net.coreprotect.database.logger;
 import java.sql.PreparedStatement;
 import java.util.Locale;
 
+import net.coreprotect.event.CoreProtectPreCommandLogEvent;
 import org.bukkit.Location;
 
 import net.coreprotect.CoreProtect;
@@ -29,11 +30,13 @@ public class CommandLogger {
             }
 
             CoreProtectPreLogEvent event = new CoreProtectPreLogEvent(user);
+            CoreProtectPreCommandLogEvent commandEvent = new CoreProtectPreCommandLogEvent(user, message);
             if (Config.getGlobal().API_ENABLED) {
                 CoreProtect.getInstance().getServer().getPluginManager().callEvent(event);
+                CoreProtect.getInstance().getServer().getPluginManager().callEvent(commandEvent);
             }
 
-            if (event.isCancelled()) {
+            if (event.isCancelled() || commandEvent.isCancelled()) {
                 return;
             }
 

--- a/src/main/java/net/coreprotect/event/CoreProtectPreCommandLogEvent.java
+++ b/src/main/java/net/coreprotect/event/CoreProtectPreCommandLogEvent.java
@@ -1,0 +1,57 @@
+package net.coreprotect.event;
+
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class CoreProtectPreCommandLogEvent extends Event implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancelled = false;
+    private String user;
+    private String command;
+
+    public CoreProtectPreCommandLogEvent(String user, String command) {
+        super(true); // async
+        this.user = user;
+        this.command = command;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public String getCommand() {
+        return command;
+    }
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    public void setUser(String newUser) {
+        if (newUser == null || newUser.isEmpty()) {
+            throw new IllegalArgumentException("Invalid user");
+        }
+
+        this.user = newUser;
+    }
+
+    public void setCommand(String newCommand){
+        if (newCommand == null || newCommand.isEmpty()){
+            throw new IllegalArgumentException("Invalid Command");
+        }
+        this.command = newCommand;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+}
+


### PR DESCRIPTION
This event allows API users to cancel specifically the command logging process versus any logging done for a user.