### PR TITLE
CoreProtectAPI: allow rolling back containers

### DIFF
--- a/src/main/java/net/coreprotect/CoreProtectAPI.java
+++ b/src/main/java/net/coreprotect/CoreProtectAPI.java
@@ -459,7 +459,8 @@ public class CoreProtectAPI extends Queue {
             actionList.add(1);
         }
 
-        actionList.removeIf(actionListItem -> actionListItem > 3);
+        // What on earth was this meant to solve?
+//        actionList.removeIf(actionListItem -> actionListItem > 3);
 
         if (restrictUsers.size() == 0) {
             restrictUsers.add("#global");

--- a/src/main/java/net/coreprotect/CoreProtectAPI.java
+++ b/src/main/java/net/coreprotect/CoreProtectAPI.java
@@ -459,7 +459,7 @@ public class CoreProtectAPI extends Queue {
             actionList.add(1);
         }
 
-        // What on earth was this meant to solve?
+        // What on earth was this meant to solve? - @bdotsamir
 //        actionList.removeIf(actionListItem -> actionListItem > 3);
 
         if (restrictUsers.size() == 0) {

--- a/src/main/java/net/coreprotect/command/CommandHandler.java
+++ b/src/main/java/net/coreprotect/command/CommandHandler.java
@@ -55,7 +55,7 @@ public class CommandHandler implements CommandExecutor {
         String[] argumentArray = inputArguments.clone();
         List<Integer> result = new ArrayList<>();
         int count = 0;
-        int next = 0;
+        int next = 0; // TODO: Only ever 1 or 0. Boolean?
         for (String argument : argumentArray) {
             if (count > 0) {
                 argument = argument.trim().toLowerCase(Locale.ROOT);
@@ -129,12 +129,12 @@ public class CommandHandler implements CommandExecutor {
                     else if (argument.equals("-inv") || argument.equals("inv-") || argument.equals("-inventory") || argument.equals("inventory-") || argument.equals("-inventories")) {
                         result.add(4);
                         result.add(11);
-                        result.add(1);
+                        result.add(1); // FIXME: I think this is supposed to be 0. Removed from inv
                     }
                     else if (argument.equals("+inv") || argument.equals("inv+") || argument.equals("+inventory") || argument.equals("inventory+") || argument.equals("+inventories")) {
                         result.add(4);
                         result.add(11);
-                        result.add(0);
+                        result.add(0); // FIXME: above, this should be 1? Added to inv
                     }
                     else if (argument.equals("item") || argument.equals("items")) {
                         result.add(11);

--- a/src/main/java/net/coreprotect/command/RollbackRestoreCommand.java
+++ b/src/main/java/net/coreprotect/command/RollbackRestoreCommand.java
@@ -258,7 +258,9 @@ public class RollbackRestoreCommand {
                 int y = 0;
                 int z = 0;
                 if (rollbackusers.contains("#container")) {
+                    // If the users we want to roll back includes "#container" and we're rolling back player inventories ...
                     if (argAction.contains(11)) {
+                        // ... fail out.
                         Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.INVALID_USERNAME, "#container"));
                         return;
                     }
@@ -275,44 +277,49 @@ public class RollbackRestoreCommand {
                             }
                         }
                     }
-                    if (valid) {
-                        if (preview > 0) {
-                            Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.PREVIEW_TRANSACTION, Selector.FIRST));
-                            return;
-                        }
-                        else {
-                            String lcommand = ConfigHandler.lookupCommand.get(player.getName());
-                            String[] data = lcommand.split("\\.");
-                            x = Integer.parseInt(data[0]);
-                            y = Integer.parseInt(data[1]);
-                            z = Integer.parseInt(data[2]);
-                            wid = Integer.parseInt(data[3]);
-                            argAction.add(5);
-                            argRadius = null;
-                            argWid = 0;
-                            lo = new Location(Bukkit.getServer().getWorld(Util.getWorldName(wid)), x, y, z);
-                            Block block = lo.getBlock();
-                            if (block.getState() instanceof Chest) {
-                                BlockFace[] blockFaces = new BlockFace[] { BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST };
-                                for (BlockFace face : blockFaces) {
-                                    if (block.getRelative(face, 1).getState() instanceof Chest) {
-                                        Block relative = block.getRelative(face, 1);
-                                        int x2 = relative.getX();
-                                        int z2 = relative.getZ();
-                                        double newX = (x + x2) / 2.0;
-                                        double newZ = (z + z2) / 2.0;
-                                        lo.setX(newX);
-                                        lo.setZ(newZ);
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    else {
+
+                    // @bdotsamir: swap logic to reduce indentation
+                    if (!valid) {
                         Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.INVALID_CONTAINER));
                         return;
                     }
+
+                    if (preview > 0) {
+                        Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.PREVIEW_TRANSACTION, Selector.FIRST));
+                        return;
+                    }
+
+                    // @bdotsamir: remove else to reduce indentation
+                    String lcommand = ConfigHandler.lookupCommand.get(player.getName());
+                    String[] data = lcommand.split("\\.");
+                    x = Integer.parseInt(data[0]);
+                    y = Integer.parseInt(data[1]);
+                    z = Integer.parseInt(data[2]);
+                    wid = Integer.parseInt(data[3]);
+                    // This is the only instance where 5 is added to the argAction list.
+                    // This only ever happens when the rollbackUsers includes "#container"
+                    // So far, it's unclear what action 5 does.
+                    argAction.add(5);
+                    argRadius = null;
+                    argWid = 0;
+                    lo = new Location(Bukkit.getServer().getWorld(Util.getWorldName(wid)), x, y, z);
+                    Block block = lo.getBlock();
+                    if (block.getState() instanceof Chest) {
+                        BlockFace[] blockFaces = new BlockFace[]{BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST};
+                        for (BlockFace face : blockFaces) {
+                            if (block.getRelative(face, 1).getState() instanceof Chest) {
+                                Block relative = block.getRelative(face, 1);
+                                int x2 = relative.getX();
+                                int z2 = relative.getZ();
+                                double newX = (x + x2) / 2.0;
+                                double newZ = (z + z2) / 2.0;
+                                lo.setX(newX);
+                                lo.setZ(newZ);
+                                break;
+                            }
+                        }
+                    }
+
                 }
 
                 final List<String> rollbackusers2 = rollbackusers;

--- a/src/main/java/net/coreprotect/database/Rollback.java
+++ b/src/main/java/net/coreprotect/database/Rollback.java
@@ -121,6 +121,7 @@ public class Rollback extends Queue {
             List<Object> itemRestrictList = new ArrayList<>(restrictList);
             Map<Object, Boolean> itemExcludeList = new HashMap<>(excludeList);
 
+            // Action 1: Place block / container add / player login / BUG?: inv remove
             if (actionList.contains(1)) {
                 for (Object target : restrictList) {
                     if (target instanceof Material) {
@@ -715,7 +716,7 @@ public class Rollback extends Queue {
                                                             inventory.clear();
                                                         }
                                                     }
-                                                    else if (BlockGroup.CONTAINERS.contains(Material.ARMOR_STAND)) {
+                                                    else if (BlockGroup.CONTAINERS.contains(Material.ARMOR_STAND)) { // TODO: THIS IS ALWAYS TRUE
                                                         if ((oldTypeMaterial == Material.ARMOR_STAND)) {
                                                             for (Entity entity : block.getChunk().getEntities()) {
                                                                 if (entity instanceof ArmorStand) {
@@ -1461,7 +1462,7 @@ public class Rollback extends Queue {
                     }
 
                     if (targetCount == 0) {
-                        restrictTargets = restrictTargets.append("" + targetName + "");
+                        restrictTargets = restrictTargets.append("" + targetName + ""); // TODO: Are these "" + x + "" necessary? If the intent is toString, targetName is already always a string.
                     }
                     else {
                         restrictTargets.append(", ").append(targetName);


### PR DESCRIPTION
I've noticed that when rolling back using the api, there's no call to `ContainerRollback.performContainerRollbackRestore()`. The only place this method is called is via the /co rollback command, which does not utilize the API.

I'm going to try to mirror what the command does into the API to the best of my abilities.