### PR TITLE
Refactor Thread Creation to ThreadFactory for better Thread namings

### DIFF
--- a/docs/api/version/v7.md
+++ b/docs/api/version/v7.md
@@ -369,7 +369,7 @@ public void run() {
 }
 }
 Runnable runnable = new BasicThread();
-Thread thread = new Thread(runnable);
+Thread thread = Util.THREAD_FACTORY.newThread(runnable);
 thread.start();
 ``` 
 
@@ -443,7 +443,7 @@ class BasicThread implements Runnable {
   }
 }
 Runnable runnable = new BasicThread();
-Thread thread = new Thread(runnable);
+Thread thread = Util.THREAD_FACTORY.newThread(runnable);
 thread.start();
 ``` 
 

--- a/docs/api/version/v8.md
+++ b/docs/api/version/v8.md
@@ -369,7 +369,7 @@ public void run() {
 }
 }
 Runnable runnable = new BasicThread();
-Thread thread = new Thread(runnable);
+Thread thread = Util.THREAD_FACTORY.newThread(runnable);
 thread.start();
 ``` 
 
@@ -443,7 +443,7 @@ class BasicThread implements Runnable {
   }
 }
 Runnable runnable = new BasicThread();
-Thread thread = new Thread(runnable);
+Thread thread = Util.THREAD_FACTORY.newThread(runnable);
 thread.start();
 ``` 
 

--- a/docs/api/version/v9.md
+++ b/docs/api/version/v9.md
@@ -391,7 +391,7 @@ public void run() {
 }
 }
 Runnable runnable = new BasicThread();
-Thread thread = new Thread(runnable);
+Thread thread = Util.THREAD_FACTORY.newThread(runnable);
 thread.start();
 ``` 
 
@@ -497,7 +497,7 @@ class BasicThread implements Runnable {
   }
 }
 Runnable runnable = new BasicThread();
-Thread thread = new Thread(runnable);
+Thread thread = Util.THREAD_FACTORY.newThread(runnable);
 thread.start();
 ``` 
 

--- a/src/main/java/net/coreprotect/CoreProtect.java
+++ b/src/main/java/net/coreprotect/CoreProtect.java
@@ -1,17 +1,5 @@
 package net.coreprotect;
 
-import java.io.File;
-import java.util.Iterator;
-import java.util.Map.Entry;
-
-import org.bstats.bukkit.MetricsLite;
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.block.data.BlockData;
-import org.bukkit.entity.Player;
-import org.bukkit.plugin.PluginDescriptionFile;
-import org.bukkit.plugin.java.JavaPlugin;
-
 import net.coreprotect.command.CommandHandler;
 import net.coreprotect.command.TabHandler;
 import net.coreprotect.config.Config;
@@ -30,6 +18,17 @@ import net.coreprotect.utility.Chat;
 import net.coreprotect.utility.Color;
 import net.coreprotect.utility.Teleport;
 import net.coreprotect.utility.Util;
+import org.bstats.bukkit.MetricsLite;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.PluginDescriptionFile;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.util.Iterator;
+import java.util.Map.Entry;
 
 public final class CoreProtect extends JavaPlugin {
 
@@ -102,7 +101,7 @@ public final class CoreProtect extends JavaPlugin {
 
             Scheduler.scheduleSyncDelayedTask(this, () -> {
                 try {
-                    Thread networkHandler = new Thread(new NetworkHandler(true, true));
+                    Thread networkHandler = Util.THREAD_FACTORY.newThread(new NetworkHandler(true, true));
                     networkHandler.start();
                 }
                 catch (Exception e) {
@@ -110,7 +109,7 @@ public final class CoreProtect extends JavaPlugin {
                 }
             }, 0);
 
-            Thread cacheCleanUpThread = new Thread(new CacheHandler());
+            Thread cacheCleanUpThread = Util.THREAD_FACTORY.newThread(new CacheHandler());
             cacheCleanUpThread.start();
 
             Consumer.startConsumer();

--- a/src/main/java/net/coreprotect/command/CommandHandler.java
+++ b/src/main/java/net/coreprotect/command/CommandHandler.java
@@ -1,25 +1,5 @@
 package net.coreprotect.command;
 
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.command.BlockCommandSender;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
-import org.bukkit.command.CommandSender;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Player;
-
 import net.coreprotect.bukkit.BukkitAdapter;
 import net.coreprotect.config.Config;
 import net.coreprotect.config.ConfigHandler;
@@ -30,6 +10,19 @@ import net.coreprotect.thread.NetworkHandler;
 import net.coreprotect.utility.Chat;
 import net.coreprotect.utility.Color;
 import net.coreprotect.utility.Util;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.command.BlockCommandSender;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+
+import java.math.BigDecimal;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class CommandHandler implements CommandExecutor {
     private static CommandHandler instance;
@@ -1269,7 +1262,7 @@ public class CommandHandler implements CommandExecutor {
                             }
                         }
                     }
-                    (new Thread(new updateAlert())).start();
+                    (Util.THREAD_FACTORY.newThread(new updateAlert())).start();
                 }
             }
 

--- a/src/main/java/net/coreprotect/command/LookupCommand.java
+++ b/src/main/java/net/coreprotect/command/LookupCommand.java
@@ -1,14 +1,21 @@
 package net.coreprotect.command;
 
-import java.nio.charset.StandardCharsets;
-import java.sql.Connection;
-import java.sql.Statement;
-import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-
+import com.google.common.base.Strings;
+import net.coreprotect.config.Config;
+import net.coreprotect.config.ConfigHandler;
+import net.coreprotect.database.Database;
+import net.coreprotect.database.Lookup;
+import net.coreprotect.database.logger.ItemLogger;
+import net.coreprotect.database.lookup.*;
+import net.coreprotect.database.statement.UserStatement;
+import net.coreprotect.language.Phrase;
+import net.coreprotect.language.Selector;
+import net.coreprotect.listener.channel.PluginChannelHandshakeListener;
+import net.coreprotect.listener.channel.PluginChannelListener;
+import net.coreprotect.utility.Chat;
+import net.coreprotect.utility.ChatMessage;
+import net.coreprotect.utility.Color;
+import net.coreprotect.utility.Util;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -20,27 +27,14 @@ import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 
-import com.google.common.base.Strings;
-
-import net.coreprotect.config.Config;
-import net.coreprotect.config.ConfigHandler;
-import net.coreprotect.database.Database;
-import net.coreprotect.database.Lookup;
-import net.coreprotect.database.logger.ItemLogger;
-import net.coreprotect.database.lookup.BlockLookup;
-import net.coreprotect.database.lookup.ChestTransactionLookup;
-import net.coreprotect.database.lookup.InteractionLookup;
-import net.coreprotect.database.lookup.PlayerLookup;
-import net.coreprotect.database.lookup.SignMessageLookup;
-import net.coreprotect.database.statement.UserStatement;
-import net.coreprotect.language.Phrase;
-import net.coreprotect.language.Selector;
-import net.coreprotect.listener.channel.PluginChannelHandshakeListener;
-import net.coreprotect.listener.channel.PluginChannelListener;
-import net.coreprotect.utility.Chat;
-import net.coreprotect.utility.ChatMessage;
-import net.coreprotect.utility.Color;
-import net.coreprotect.utility.Util;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 public class LookupCommand {
     protected static void runCommand(CommandSender player, Command command, boolean permission, String[] args) {
@@ -375,7 +369,7 @@ public class LookupCommand {
                 }
             }
             Runnable runnable = new BasicThread();
-            Thread thread = new Thread(runnable);
+            Thread thread = Util.THREAD_FACTORY.newThread(runnable);
             thread.start();
         }
         else if (type == 2 || type == 3 || type == 7 || type == 8) {
@@ -495,7 +489,7 @@ public class LookupCommand {
                 }
             }
             Runnable runnable = new BasicThread();
-            Thread thread = new Thread(runnable);
+            Thread thread = Util.THREAD_FACTORY.newThread(runnable);
             thread.start();
         }
         else if (type == 4 || type == 5) {
@@ -1096,7 +1090,7 @@ public class LookupCommand {
                         }
                     }
                     Runnable runnable = new BasicThread2();
-                    Thread thread = new Thread(runnable);
+                    Thread thread = Util.THREAD_FACTORY.newThread(runnable);
                     thread.start();
                 }
                 catch (Exception e) {

--- a/src/main/java/net/coreprotect/command/PurgeCommand.java
+++ b/src/main/java/net/coreprotect/command/PurgeCommand.java
@@ -1,18 +1,5 @@
 package net.coreprotect.command;
 
-import java.io.File;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.text.NumberFormat;
-import java.util.Arrays;
-import java.util.List;
-
-import org.bukkit.Location;
-import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
-
 import net.coreprotect.config.Config;
 import net.coreprotect.config.ConfigHandler;
 import net.coreprotect.consumer.Consumer;
@@ -24,6 +11,18 @@ import net.coreprotect.utility.Chat;
 import net.coreprotect.utility.ChatMessage;
 import net.coreprotect.utility.Color;
 import net.coreprotect.utility.Util;
+import org.bukkit.Location;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.text.NumberFormat;
+import java.util.Arrays;
+import java.util.List;
 
 public class PurgeCommand extends Consumer {
 
@@ -386,7 +385,7 @@ public class PurgeCommand extends Consumer {
         }
 
         Runnable runnable = new BasicThread();
-        Thread thread = new Thread(runnable);
+        Thread thread = Util.THREAD_FACTORY.newThread(runnable);
         thread.start();
     }
 }

--- a/src/main/java/net/coreprotect/command/ReloadCommand.java
+++ b/src/main/java/net/coreprotect/command/ReloadCommand.java
@@ -1,13 +1,13 @@
 package net.coreprotect.command;
 
-import org.bukkit.command.CommandSender;
-
 import net.coreprotect.config.ConfigHandler;
 import net.coreprotect.consumer.Consumer;
 import net.coreprotect.language.Phrase;
 import net.coreprotect.thread.NetworkHandler;
 import net.coreprotect.utility.Chat;
 import net.coreprotect.utility.Color;
+import net.coreprotect.utility.Util;
+import org.bukkit.command.CommandSender;
 
 public class ReloadCommand {
     protected static void runCommand(final CommandSender player, boolean permission, String[] args) {
@@ -44,7 +44,7 @@ public class ReloadCommand {
                         ConfigHandler.performInitialization(false);
                         Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.RELOAD_SUCCESS));
 
-                        Thread networkHandler = new Thread(new NetworkHandler(false, false));
+                        Thread networkHandler = Util.THREAD_FACTORY.newThread(new NetworkHandler(false, false));
                         networkHandler.start();
                     }
                     catch (Exception e) {
@@ -56,7 +56,7 @@ public class ReloadCommand {
                 }
             }
             Runnable runnable = new BasicThread();
-            Thread thread = new Thread(runnable);
+            Thread thread = Util.THREAD_FACTORY.newThread(runnable);
             thread.start();
         }
         else {

--- a/src/main/java/net/coreprotect/command/RollbackRestoreCommand.java
+++ b/src/main/java/net/coreprotect/command/RollbackRestoreCommand.java
@@ -1,12 +1,16 @@
 package net.coreprotect.command;
 
-import java.sql.Connection;
-import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-
+import net.coreprotect.config.Config;
+import net.coreprotect.config.ConfigHandler;
+import net.coreprotect.database.ContainerRollback;
+import net.coreprotect.database.Database;
+import net.coreprotect.database.Rollback;
+import net.coreprotect.database.lookup.PlayerLookup;
+import net.coreprotect.language.Phrase;
+import net.coreprotect.language.Selector;
+import net.coreprotect.utility.Chat;
+import net.coreprotect.utility.Color;
+import net.coreprotect.utility.Util;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -19,17 +23,12 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 
-import net.coreprotect.config.Config;
-import net.coreprotect.config.ConfigHandler;
-import net.coreprotect.database.ContainerRollback;
-import net.coreprotect.database.Database;
-import net.coreprotect.database.Rollback;
-import net.coreprotect.database.lookup.PlayerLookup;
-import net.coreprotect.language.Phrase;
-import net.coreprotect.language.Selector;
-import net.coreprotect.utility.Chat;
-import net.coreprotect.utility.Color;
-import net.coreprotect.utility.Util;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 public class RollbackRestoreCommand {
     protected static void runCommand(CommandSender player, Command command, boolean permission, String[] args, Location argLocation, long forceStart, long forceEnd) {
@@ -458,7 +457,7 @@ public class RollbackRestoreCommand {
                             }
                         }
                         Runnable runnable = new BasicThread2();
-                        Thread thread = new Thread(runnable);
+                        Thread thread = Util.THREAD_FACTORY.newThread(runnable);
                         thread.start();
                     }
                     catch (Exception e) {

--- a/src/main/java/net/coreprotect/command/StatusCommand.java
+++ b/src/main/java/net/coreprotect/command/StatusCommand.java
@@ -1,11 +1,5 @@
 package net.coreprotect.command;
 
-import java.util.concurrent.ConcurrentHashMap;
-
-import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
-import org.bukkit.plugin.PluginDescriptionFile;
-
 import net.coreprotect.CoreProtect;
 import net.coreprotect.config.Config;
 import net.coreprotect.config.ConfigHandler;
@@ -17,6 +11,12 @@ import net.coreprotect.patch.Patch;
 import net.coreprotect.thread.NetworkHandler;
 import net.coreprotect.utility.Chat;
 import net.coreprotect.utility.Color;
+import net.coreprotect.utility.Util;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.PluginDescriptionFile;
+
+import java.util.concurrent.ConcurrentHashMap;
 
 public class StatusCommand {
     private static ConcurrentHashMap<String, Boolean> alert = new ConcurrentHashMap<>();
@@ -127,7 +127,7 @@ public class StatusCommand {
             }
         }
         Runnable runnable = new BasicThread();
-        Thread thread = new Thread(runnable);
+        Thread thread = Util.THREAD_FACTORY.newThread(runnable);
         thread.start();
     }
 }

--- a/src/main/java/net/coreprotect/consumer/Consumer.java
+++ b/src/main/java/net/coreprotect/consumer/Consumer.java
@@ -1,19 +1,15 @@
 package net.coreprotect.consumer;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
+import net.coreprotect.CoreProtect;
+import net.coreprotect.config.ConfigHandler;
+import net.coreprotect.consumer.process.Process;
+import net.coreprotect.utility.Util;
 import org.bukkit.Bukkit;
 import org.bukkit.block.BlockState;
 import org.bukkit.inventory.ItemStack;
 
-import net.coreprotect.CoreProtect;
-import net.coreprotect.config.ConfigHandler;
-import net.coreprotect.consumer.process.Process;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class Consumer extends Process implements Runnable, Thread.UncaughtExceptionHandler {
 
@@ -147,7 +143,7 @@ public class Consumer extends Process implements Runnable, Thread.UncaughtExcept
 
     public static void startConsumer() {
         if (!isRunning()) {
-            consumerThread = new Thread(new Consumer());
+            consumerThread = Util.THREAD_FACTORY.newThread(new Consumer());
             consumerThread.setUncaughtExceptionHandler(new Consumer());
             consumerThread.start();
         }

--- a/src/main/java/net/coreprotect/listener/entity/HangingBreakByEntityListener.java
+++ b/src/main/java/net/coreprotect/listener/entity/HangingBreakByEntityListener.java
@@ -1,9 +1,16 @@
 package net.coreprotect.listener.entity;
 
-import java.sql.Connection;
-import java.sql.Statement;
-import java.util.Locale;
-
+import net.coreprotect.bukkit.BukkitAdapter;
+import net.coreprotect.config.Config;
+import net.coreprotect.config.ConfigHandler;
+import net.coreprotect.consumer.Queue;
+import net.coreprotect.database.Database;
+import net.coreprotect.database.lookup.BlockLookup;
+import net.coreprotect.language.Phrase;
+import net.coreprotect.listener.player.PlayerInteractEntityListener;
+import net.coreprotect.utility.Chat;
+import net.coreprotect.utility.Color;
+import net.coreprotect.utility.Util;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.block.BlockState;
@@ -17,17 +24,9 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.hanging.HangingBreakByEntityEvent;
 import org.bukkit.inventory.ItemStack;
 
-import net.coreprotect.bukkit.BukkitAdapter;
-import net.coreprotect.config.Config;
-import net.coreprotect.config.ConfigHandler;
-import net.coreprotect.consumer.Queue;
-import net.coreprotect.database.Database;
-import net.coreprotect.database.lookup.BlockLookup;
-import net.coreprotect.language.Phrase;
-import net.coreprotect.listener.player.PlayerInteractEntityListener;
-import net.coreprotect.utility.Chat;
-import net.coreprotect.utility.Color;
-import net.coreprotect.utility.Util;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.Locale;
 
 public final class HangingBreakByEntityListener extends Queue implements Listener {
 
@@ -86,7 +85,7 @@ public final class HangingBreakByEntityListener extends Queue implements Listene
             }
         }
         Runnable runnable = new BasicThread();
-        Thread thread = new Thread(runnable);
+        Thread thread = Util.THREAD_FACTORY.newThread(runnable);
         thread.start();
     }
 

--- a/src/main/java/net/coreprotect/listener/player/ArmorStandManipulateListener.java
+++ b/src/main/java/net/coreprotect/listener/player/ArmorStandManipulateListener.java
@@ -1,9 +1,15 @@
 package net.coreprotect.listener.player;
 
-import java.sql.Connection;
-import java.sql.Statement;
-import java.util.List;
-
+import net.coreprotect.config.Config;
+import net.coreprotect.config.ConfigHandler;
+import net.coreprotect.consumer.Queue;
+import net.coreprotect.database.Database;
+import net.coreprotect.database.lookup.ChestTransactionLookup;
+import net.coreprotect.language.Phrase;
+import net.coreprotect.model.BlockGroup;
+import net.coreprotect.utility.Chat;
+import net.coreprotect.utility.Color;
+import net.coreprotect.utility.Util;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.ArmorStand;
@@ -15,16 +21,9 @@ import org.bukkit.event.player.PlayerArmorStandManipulateEvent;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.ItemStack;
 
-import net.coreprotect.config.Config;
-import net.coreprotect.config.ConfigHandler;
-import net.coreprotect.consumer.Queue;
-import net.coreprotect.database.Database;
-import net.coreprotect.database.lookup.ChestTransactionLookup;
-import net.coreprotect.language.Phrase;
-import net.coreprotect.model.BlockGroup;
-import net.coreprotect.utility.Chat;
-import net.coreprotect.utility.Color;
-import net.coreprotect.utility.Util;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.List;
 
 public final class ArmorStandManipulateListener extends Queue implements Listener {
 
@@ -75,7 +74,7 @@ public final class ArmorStandManipulateListener extends Queue implements Listene
             }
         }
         Runnable runnable = new BasicThread();
-        Thread thread = new Thread(runnable);
+        Thread thread = Util.THREAD_FACTORY.newThread(runnable);
         thread.start();
     }
 

--- a/src/main/java/net/coreprotect/listener/player/PlayerInteractListener.java
+++ b/src/main/java/net/coreprotect/listener/player/PlayerInteractListener.java
@@ -1,24 +1,26 @@
 package net.coreprotect.listener.player;
 
-import java.sql.Connection;
-import java.sql.Statement;
-import java.util.Arrays;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-
-import org.bukkit.GameMode;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.Tag;
-import org.bukkit.World;
-import org.bukkit.block.Block;
-import org.bukkit.block.BlockState;
-import org.bukkit.block.Chest;
-import org.bukkit.block.DoubleChest;
-import org.bukkit.block.Jukebox;
-import org.bukkit.block.Sign;
+import net.coreprotect.CoreProtect;
+import net.coreprotect.bukkit.BukkitAdapter;
+import net.coreprotect.config.Config;
+import net.coreprotect.config.ConfigHandler;
+import net.coreprotect.consumer.Queue;
+import net.coreprotect.database.Database;
+import net.coreprotect.database.lookup.BlockLookup;
+import net.coreprotect.database.lookup.ChestTransactionLookup;
+import net.coreprotect.database.lookup.InteractionLookup;
+import net.coreprotect.database.lookup.SignMessageLookup;
+import net.coreprotect.language.Phrase;
+import net.coreprotect.listener.block.CampfireStartListener;
+import net.coreprotect.model.BlockGroup;
+import net.coreprotect.paper.PaperAdapter;
+import net.coreprotect.thread.CacheHandler;
+import net.coreprotect.thread.Scheduler;
+import net.coreprotect.utility.Chat;
+import net.coreprotect.utility.Color;
+import net.coreprotect.utility.Util;
+import org.bukkit.*;
+import org.bukkit.block.*;
 import org.bukkit.block.data.Bisected;
 import org.bukkit.block.data.Bisected.Half;
 import org.bukkit.block.data.BlockData;
@@ -41,25 +43,13 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 
-import net.coreprotect.CoreProtect;
-import net.coreprotect.bukkit.BukkitAdapter;
-import net.coreprotect.config.Config;
-import net.coreprotect.config.ConfigHandler;
-import net.coreprotect.consumer.Queue;
-import net.coreprotect.database.Database;
-import net.coreprotect.database.lookup.BlockLookup;
-import net.coreprotect.database.lookup.ChestTransactionLookup;
-import net.coreprotect.database.lookup.InteractionLookup;
-import net.coreprotect.database.lookup.SignMessageLookup;
-import net.coreprotect.language.Phrase;
-import net.coreprotect.listener.block.CampfireStartListener;
-import net.coreprotect.model.BlockGroup;
-import net.coreprotect.paper.PaperAdapter;
-import net.coreprotect.thread.CacheHandler;
-import net.coreprotect.thread.Scheduler;
-import net.coreprotect.utility.Chat;
-import net.coreprotect.utility.Color;
-import net.coreprotect.utility.Util;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public final class PlayerInteractListener extends Queue implements Listener {
 
@@ -157,7 +147,7 @@ public final class PlayerInteractListener extends Queue implements Listener {
             }
 
             Runnable runnable = new BasicThread();
-            Thread thread = new Thread(runnable);
+            Thread thread = Util.THREAD_FACTORY.newThread(runnable);
             thread.start();
 
             if (checkBlockData instanceof Bisected) {
@@ -255,7 +245,7 @@ public final class PlayerInteractListener extends Queue implements Listener {
                         }
 
                         Runnable runnable = new BasicThread();
-                        Thread thread = new Thread(runnable);
+                        Thread thread = Util.THREAD_FACTORY.newThread(runnable);
                         thread.start();
                         event.setCancelled(true);
                     }
@@ -327,7 +317,7 @@ public final class PlayerInteractListener extends Queue implements Listener {
                         }
 
                         Runnable runnable = new BasicThread();
-                        Thread thread = new Thread(runnable);
+                        Thread thread = Util.THREAD_FACTORY.newThread(runnable);
                         thread.start();
                         event.setCancelled(true);
                     }
@@ -394,7 +384,7 @@ public final class PlayerInteractListener extends Queue implements Listener {
                         }
 
                         Runnable runnable = new BasicThread();
-                        Thread thread = new Thread(runnable);
+                        Thread thread = Util.THREAD_FACTORY.newThread(runnable);
                         thread.start();
 
                         if (!BlockGroup.SAFE_INTERACT_BLOCKS.contains(type) || player.isSneaking()) {
@@ -488,7 +478,7 @@ public final class PlayerInteractListener extends Queue implements Listener {
                         }
 
                         Runnable runnable = new BasicThread();
-                        Thread thread = new Thread(runnable);
+                        Thread thread = Util.THREAD_FACTORY.newThread(runnable);
                         thread.start();
 
                         Util.updateInventory(event.getPlayer());

--- a/src/main/java/net/coreprotect/patch/Patch.java
+++ b/src/main/java/net/coreprotect/patch/Patch.java
@@ -1,5 +1,14 @@
 package net.coreprotect.patch;
 
+import net.coreprotect.CoreProtect;
+import net.coreprotect.config.ConfigHandler;
+import net.coreprotect.consumer.Consumer;
+import net.coreprotect.database.Database;
+import net.coreprotect.language.Phrase;
+import net.coreprotect.utility.Chat;
+import net.coreprotect.utility.Color;
+import net.coreprotect.utility.Util;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.lang.reflect.Method;
@@ -12,15 +21,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
-
-import net.coreprotect.CoreProtect;
-import net.coreprotect.config.ConfigHandler;
-import net.coreprotect.consumer.Consumer;
-import net.coreprotect.database.Database;
-import net.coreprotect.language.Phrase;
-import net.coreprotect.utility.Chat;
-import net.coreprotect.utility.Color;
-import net.coreprotect.utility.Util;
 
 public class Patch {
 
@@ -302,8 +302,8 @@ public class Patch {
                         }
                     }
                 }
-                (new Thread(new runPatch())).start();
-                (new Thread(new patchStatus())).start();
+                (Util.THREAD_FACTORY.newThread(new runPatch())).start();
+                (Util.THREAD_FACTORY.newThread(new patchStatus())).start();
             }
             else if (lastVersion[0] == 0) {
                 int unixtimestamp = (int) (System.currentTimeMillis() / 1000L);

--- a/src/main/java/net/coreprotect/utility/Util.java
+++ b/src/main/java/net/coreprotect/utility/Util.java
@@ -1,55 +1,6 @@
 package net.coreprotect.utility;
 
-import java.io.ByteArrayOutputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.text.DecimalFormat;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
-
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.World;
-import org.bukkit.block.Banner;
-import org.bukkit.block.Block;
-import org.bukkit.block.BlockState;
-import org.bukkit.block.Chest;
-import org.bukkit.block.CommandBlock;
-import org.bukkit.block.Jukebox;
-import org.bukkit.block.ShulkerBox;
-import org.bukkit.block.banner.Pattern;
-import org.bukkit.block.data.BlockData;
-import org.bukkit.block.data.Waterlogged;
-import org.bukkit.command.ConsoleCommandSender;
-import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.configuration.serialization.ConfigurationSerialization;
-import org.bukkit.configuration.serialization.DelegateDeserialization;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.ItemFrame;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Player;
-import org.bukkit.inventory.BlockInventoryHolder;
-import org.bukkit.inventory.EntityEquipment;
-import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.PlayerInventory;
-import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.plugin.Plugin;
-import org.bukkit.util.io.BukkitObjectOutputStream;
-
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import net.coreprotect.CoreProtect;
 import net.coreprotect.bukkit.BukkitAdapter;
 import net.coreprotect.config.Config;
@@ -62,11 +13,46 @@ import net.coreprotect.thread.CacheHandler;
 import net.coreprotect.thread.Scheduler;
 import net.coreprotect.utility.serialize.ItemMetaHandler;
 import net.coreprotect.worldedit.CoreProtectEditSessionEvent;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.*;
+import org.bukkit.block.banner.Pattern;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Waterlogged;
+import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.configuration.serialization.ConfigurationSerialization;
+import org.bukkit.configuration.serialization.DelegateDeserialization;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.ItemFrame;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.*;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.util.io.BukkitObjectOutputStream;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.text.DecimalFormat;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.concurrent.ThreadFactory;
 
 public class Util extends Queue {
 
     public static final java.util.regex.Pattern tagParser = java.util.regex.Pattern.compile(Chat.COMPONENT_TAG_OPEN + "(.+?)" + Chat.COMPONENT_TAG_CLOSE + "|(.+?)", java.util.regex.Pattern.DOTALL);
     private static final String NAMESPACE = "minecraft:";
+
+    public static final ThreadFactory THREAD_FACTORY = new ThreadFactoryBuilder()
+            .setNameFormat("CoreProtect-%d")
+            .build();
 
     private Util() {
         throw new IllegalStateException("Utility class");


### PR DESCRIPTION
In this pull request, I've made a significant change to the way threads are created. Instead of using the default thread naming convention, which results in generic names like `Thread-XX,` I've implemented a `ThreadFactory` to assign meaningful names to threads. 

This change is highly beneficial for several reasons:

Improved Debugging and Maintenance:
> Named threads provide clear and informative identifiers, making it significantly easier to identify the purpose and origin of a specific thread during debugging and code maintenance. It reduces the ambiguity associated with generic thread names and simplifies the troubleshooting process.

Enhanced Logging and Monitoring:
> When threads are assigned meaningful names, the logs and monitoring tools can display more informative and human-readable information. This is especially valuable in a multi-threaded Minecraft Servers, where tracking thread activity is crucial for performance optimization and issue identification.

My IDE has also refactored the imports, if this is a problem, let me know!