### PR TITLE
Update Folia API dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     compileOnly('com.sk89q.worldedit:worldedit-bukkit:7.0.0-SNAPSHOT') {
         exclude group: 'org.bukkit'
     }
-    compileOnly 'dev.folia:folia-api:1.20.1-R0.1-SNAPSHOT'
+    compileOnly 'dev.folia:folia-api:1.20.2-R0.1-SNAPSHOT'
     implementation 'org.bstats:bstats-bukkit-lite:1.8'
     implementation 'com.zaxxer:HikariCP:5.0.1'
 }


### PR DESCRIPTION
Related to the commit 488392c.
Update Folia API version from 1.20.1 to 1.20.2 in `/build.gradle`.