### PR TITLE
fix: folia check to be compatible with shreddedpaper

### DIFF
--- a/src/main/java/net/coreprotect/utility/Util.java
+++ b/src/main/java/net/coreprotect/utility/Util.java
@@ -1312,7 +1312,7 @@ public class Util extends Queue {
 
     public static boolean isFolia() {
         try {
-            Class.forName("io.papermc.paper.threadedregions.ThreadedRegionizer");
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
         }
         catch (Exception e) {
             return false;


### PR DESCRIPTION
[ShreddedPaper](https://github.com/MultiPaper/ShreddedPaper) is fully compatible with all folia plugins if don't check if its folia, BUT we have an empty class for [RegionizedServer](https://github.com/MultiPaper/ShreddedPaper/pull/5/files) as MOST plugins will check for this, please be like everyone else!
