### PR TITLE
Upload artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, workflow_dispatch]
 jobs:
   build:
     name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,5 +24,13 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - name: Build
+      - name: Verify
         run: mvn -B verify
+      - name: Build
+        run: mvn -B clean install
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coreprotect
+          compression-level: 0 # .jar files are already compressed anyway
+          path: target/CoreProtect-*.jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, synchronize, reopened, workflow_dispatch]
+    types: [opened, synchronize, reopened]
 jobs:
   build:
     name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,8 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - name: Verify
-        run: mvn -B verify
       - name: Build
-        run: mvn -B clean install
+        run: mvn -B verify
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This uploads the .jar produced when the build action runs as an artifact, allowing people to download the latest dev builds without compiling from the source themselves.

The compression level is set to 0 as jar files are already compressed.