### PR TITLE
Crafter Slot Enable/Disable Support (fixes #766)

### DIFF
--- a/src/main/java/net/coreprotect/listener/player/InventoryChangeListener.java
+++ b/src/main/java/net/coreprotect/listener/player/InventoryChangeListener.java
@@ -348,7 +348,7 @@ public final class InventoryChangeListener extends Queue implements Listener {
         }
 
         // Check if the clicked slot is one of the crafter slots
-        if (event.getRawSlot() > 8) {
+        if (event.getRawSlot() < 0 || event.getRawSlot() > 8) {
             return false;
         }
 


### PR DESCRIPTION
Adds support for logging the enabling/disabling of slots inside of Crafters. Uses break/place framework, similar to sign color changing.