### PR TITLE
#611 Allow blacklist to target killed mobs

### DIFF
--- a/src/main/java/net/coreprotect/database/logger/EntityKillLogger.java
+++ b/src/main/java/net/coreprotect/database/logger/EntityKillLogger.java
@@ -30,6 +30,9 @@ public class EntityKillLogger {
             if (ConfigHandler.blacklist.get(user.toLowerCase(Locale.ROOT)) != null) {
                 return;
             }
+           if (ConfigHandler.blacklist.get(ConfigHandler.entitiesReversed.get(type).toLowerCase(Locale.ROOT)) != null) {
+                return;
+            }
 
             Location initialLocation = new Location(block.getWorld(), block.getX(), block.getY(), block.getZ());
             CoreProtectPreLogEvent event = new CoreProtectPreLogEvent(user, initialLocation);


### PR DESCRIPTION
Blacklist.txt can now blacklist the targeted mob as specified in #611 

<img width="2478" height="785" alt="image" src="https://github.com/user-attachments/assets/6a8ffd98-c37c-44e1-8f54-80769f0ee0f3" />

test below:

blacklist.txt
<img width="114" height="122" alt="image" src="https://github.com/user-attachments/assets/0b325fb8-64fb-4dea-9952-1582c67ec97a" />

spawned creeper and zombie
<img width="910" height="850" alt="image" src="https://github.com/user-attachments/assets/2dc8a3e8-aae0-48c7-aaaf-03a41c40e09e" />

only creeper  have log after killed, zombie is blacklisted
<img width="518" height="260" alt="image" src="https://github.com/user-attachments/assets/af2d355d-f655-4585-b5b7-307faaac6dce" />
