### PR TITLE
fix waterlogged bucket incorrect logging (Resolves #858)

### DIFF
--- a/src/main/java/net/coreprotect/listener/player/PlayerBucketEmptyListener.java
+++ b/src/main/java/net/coreprotect/listener/player/PlayerBucketEmptyListener.java
@@ -32,25 +32,11 @@ public final class PlayerBucketEmptyListener extends Queue implements Listener {
         }
 
         if (!event.isCancelled() && Config.getConfig(world).BUCKETS && inspect == 0) {
-            Block block = event.getBlockClicked();
+            Block block = event.getBlock();
             BlockData blockData = block.getBlockData();
             Material type = Material.WATER;
             if (event.getBucket().equals(Material.LAVA_BUCKET)) {
                 type = Material.LAVA;
-            }
-
-            boolean getRelative = true;
-            if (blockData instanceof Waterlogged) {
-                if (type.equals(Material.WATER)) {
-                    boolean isWaterlogged = ((Waterlogged) blockData).isWaterlogged();
-                    if (!isWaterlogged) {
-                        getRelative = false;
-                    }
-                }
-            }
-            if (getRelative) {
-                block = block.getRelative(event.getBlockFace());
-                blockData = block.getBlockData();
             }
 
             BlockState blockState = block.getState();

--- a/src/main/java/net/coreprotect/listener/player/PlayerBucketFillListener.java
+++ b/src/main/java/net/coreprotect/listener/player/PlayerBucketFillListener.java
@@ -19,7 +19,7 @@ public final class PlayerBucketFillListener extends Queue implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST)
     protected void onPlayerBucketFill(PlayerBucketFillEvent event) {
         String player = event.getPlayer().getName();
-        Block block = event.getBlockClicked();
+        Block block = event.getBlock();
         World world = block.getWorld();
         Material type = block.getType();
 


### PR DESCRIPTION
Simple fix for Issue #858 

By using `event.getBlock()` instead of `event.getBlockClicked()` there is no longer the need to manually check for waterlogged blocks and offset the position, as that's handled by Bukkit.

The `getBlock()` method is still present in older versions as far back as 1.14, so compatibility isn't affected.

Although the bug only affects bucket emptying, I've also changed it on `bucketFillListener` just for consistency, the result doesn't actually change.

I've tested this fix, and everything works as expected.