### PR TITLE
Add string filtering for command and chat action lookups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <artifactId>CoreProtect</artifactId>
   <version>23.1</version>
   <properties>
-    <project.branch></project.branch>
+    <project.branch>development</project.branch>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <skipTests>true</skipTests>
     <maven.compiler.source>11</maven.compiler.source>

--- a/src/main/java/net/coreprotect/command/CommandParser.java
+++ b/src/main/java/net/coreprotect/command/CommandParser.java
@@ -316,8 +316,19 @@ public class CommandParser {
     }
 
     /**
+     * Parse message filter from command arguments (m:, msg:, message:)
+     *
+     * @param inputArguments
+     *            The command arguments
+     * @return The message filter string, or empty string if not present
+     */
+    protected static String parseMessageFilter(String[] inputArguments) {
+        return ActionParser.parseMessageFilter(inputArguments);
+    }
+
+    /**
      * Helper method for formatting BigDecimal values
-     * 
+     *
      * @param input
      *            The BigDecimal value to format
      * @return The formatted string

--- a/src/main/java/net/coreprotect/command/LookupCommand.java
+++ b/src/main/java/net/coreprotect/command/LookupCommand.java
@@ -49,6 +49,7 @@ public class LookupCommand {
         boolean count = CommandParser.parseCount(args);
         boolean worldedit = CommandParser.parseWorldEdit(args);
         boolean forceglobal = CommandParser.parseForceGlobal(args);
+        String messageFilter = CommandParser.parseMessageFilter(args);
         boolean pageLookup = false;
 
         if (argBlocks == null || argExclude == null || argExcludeUsers == null) {
@@ -247,6 +248,11 @@ public class LookupCommand {
                 Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.INCOMPATIBLE_ACTION, "e:"));
                 return;
             }
+        }
+
+        if (messageFilter.length() > 0 && !argAction.contains(6) && !argAction.contains(7)) {
+            Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.INCOMPATIBLE_ACTION, "m:"));
+            return;
         }
 
         if (startTime <= 0 && !pageLookup && type == 4 && (argBlocks.size() > 0 || argUsers.size() > 0)) {
@@ -519,6 +525,9 @@ public class LookupCommand {
                     argAction = ConfigHandler.lookupAlist.get(player.getName());
                     argRadius = ConfigHandler.lookupRadius.get(player.getName());
                     ts = ConfigHandler.lookupTime.get(player.getName());
+                    if (ConfigHandler.lookupMessageFilter.get(player.getName()) != null) {
+                        messageFilter = ConfigHandler.lookupMessageFilter.get(player.getName());
+                    }
                     startTime = 1;
                     endTime = 0;
                 }
@@ -595,7 +604,7 @@ public class LookupCommand {
                         }
                     }
 
-                    Runnable runnable = new StandardLookupThread(player, command, rollbackusers, argBlocks, argExclude, argExcludeUsers, argAction, argRadius, lo, x, y, z, wid, argWid, timeStart, timeEnd, argNoisy, argExcluded, argRestricted, pa, re, type, ts, count);
+                    Runnable runnable = new StandardLookupThread(player, command, rollbackusers, argBlocks, argExclude, argExcludeUsers, argAction, argRadius, lo, x, y, z, wid, argWid, timeStart, timeEnd, argNoisy, argExcluded, argRestricted, pa, re, type, ts, count, messageFilter);
                     Thread thread = new Thread(runnable);
                     thread.start();
                 }

--- a/src/main/java/net/coreprotect/command/lookup/StandardLookupThread.java
+++ b/src/main/java/net/coreprotect/command/lookup/StandardLookupThread.java
@@ -61,8 +61,13 @@ public class StandardLookupThread implements Runnable {
     private final int typeLookup;
     private final String rtime;
     private final boolean count;
+    private final String messageFilter;
 
     public StandardLookupThread(CommandSender player, Command command, List<String> rollbackUsers, List<Object> blockList, Map<Object, Boolean> excludedBlocks, List<String> excludedUsers, List<Integer> actions, Integer[] radius, Location location, int x, int y, int z, int worldId, int argWorldId, long timeStart, long timeEnd, int noisy, int excluded, int restricted, int page, int displayResults, int typeLookup, String rtime, boolean count) {
+        this(player, command, rollbackUsers, blockList, excludedBlocks, excludedUsers, actions, radius, location, x, y, z, worldId, argWorldId, timeStart, timeEnd, noisy, excluded, restricted, page, displayResults, typeLookup, rtime, count, "");
+    }
+
+    public StandardLookupThread(CommandSender player, Command command, List<String> rollbackUsers, List<Object> blockList, Map<Object, Boolean> excludedBlocks, List<String> excludedUsers, List<Integer> actions, Integer[] radius, Location location, int x, int y, int z, int worldId, int argWorldId, long timeStart, long timeEnd, int noisy, int excluded, int restricted, int page, int displayResults, int typeLookup, String rtime, boolean count, String messageFilter) {
         this.player = player;
         this.command = command;
         this.rollbackUsers = rollbackUsers;
@@ -87,6 +92,7 @@ public class StandardLookupThread implements Runnable {
         this.typeLookup = typeLookup;
         this.rtime = rtime;
         this.count = count;
+        this.messageFilter = messageFilter;
     }
 
     @Override
@@ -101,6 +107,7 @@ public class StandardLookupThread implements Runnable {
             ConfigHandler.lookupCommand.put(player.getName(), bc);
             ConfigHandler.lookupPage.put(player.getName(), page);
             ConfigHandler.lookupTime.put(player.getName(), rtime);
+            ConfigHandler.lookupMessageFilter.put(player.getName(), messageFilter);
             ConfigHandler.lookupType.put(player.getName(), 5);
             ConfigHandler.lookupElist.put(player.getName(), excludedBlocks);
             ConfigHandler.lookupEUserlist.put(player.getName(), excludedUsers);
@@ -184,7 +191,7 @@ public class StandardLookupThread implements Runnable {
                     }
 
                     if (checkRows) {
-                        rows = Lookup.countLookupRows(statement, player, uuidList, userList, blockList, excludedBlocks, excludedUsers, actions, finalLocation, radius, rowData, timeStart, timeEnd, restrict_world, true);
+                        rows = Lookup.countLookupRows(statement, player, uuidList, userList, blockList, excludedBlocks, excludedUsers, actions, finalLocation, radius, rowData, timeStart, timeEnd, restrict_world, true, messageFilter);
                         rowData[3] = rows;
                         ConfigHandler.lookupRows.put(player.getName(), rowData);
                     }
@@ -193,7 +200,7 @@ public class StandardLookupThread implements Runnable {
                         Chat.sendMessage(player, Color.DARK_AQUA + "CoreProtect " + Color.WHITE + "- " + Phrase.build(Phrase.LOOKUP_ROWS_FOUND, row_format, (rows == 1 ? Selector.FIRST : Selector.SECOND)));
                     }
                     else if (pageStart < rows) {
-                        List<String[]> lookupList = Lookup.performPartialLookup(statement, player, uuidList, userList, blockList, excludedBlocks, excludedUsers, actions, finalLocation, radius, rowData, timeStart, timeEnd, (int) pageStart, displayResults, restrict_world, true);
+                        List<String[]> lookupList = Lookup.performPartialLookup(statement, player, uuidList, userList, blockList, excludedBlocks, excludedUsers, actions, finalLocation, radius, rowData, timeStart, timeEnd, (int) pageStart, displayResults, restrict_world, true, messageFilter);
 
                         Chat.sendMessage(player, Color.WHITE + "----- " + Color.DARK_AQUA + Phrase.build(Phrase.LOOKUP_HEADER, "CoreProtect" + Color.WHITE + " | " + Color.DARK_AQUA) + Color.WHITE + " -----");
                         if (actions.contains(6) || actions.contains(7)) { // Chat/command

--- a/src/main/java/net/coreprotect/command/parser/ActionParser.java
+++ b/src/main/java/net/coreprotect/command/parser/ActionParser.java
@@ -200,8 +200,37 @@ public class ActionParser {
     }
 
     /**
+     * Parse message filter from command arguments (m:, msg:, message:)
+     *
+     * @param inputArguments
+     *            The command arguments
+     * @return The message filter string, or empty string if not present
+     */
+    public static String parseMessageFilter(String[] inputArguments) {
+        String[] argumentArray = inputArguments.clone();
+        String result = "";
+        int count = 0;
+        for (String argument : argumentArray) {
+            if (count > 0) {
+                argument = argument.trim();
+                String lower = argument.toLowerCase(Locale.ROOT);
+                if (lower.startsWith("message:") || lower.startsWith("msg:") || lower.startsWith("m:")) {
+                    String filter = argument.replaceAll("(?i)^message:", "").replaceAll("(?i)^msg:", "").replaceAll("(?i)^m:", "");
+                    filter = filter.replaceAll("\\\\", "");
+                    filter = filter.replaceAll("'", "");
+                    if (filter.length() > 0) {
+                        result = filter;
+                    }
+                }
+            }
+            count++;
+        }
+        return result;
+    }
+
+    /**
      * Parse preview flag from command arguments
-     * 
+     *
      * @param inputArguments
      *            The command arguments
      * @return 1 for preview, 2 for preview cancel, 0 otherwise

--- a/src/main/java/net/coreprotect/config/ConfigHandler.java
+++ b/src/main/java/net/coreprotect/config/ConfigHandler.java
@@ -130,6 +130,7 @@ public class ConfigHandler extends Queue {
     public static Map<String, List<Integer>> lookupAlist = syncMap();
     public static Map<String, Integer[]> lookupRadius = syncMap();
     public static Map<String, String> lookupTime = syncMap();
+    public static Map<String, String> lookupMessageFilter = syncMap();
     public static Map<String, Long[]> lookupRows = syncMap();
     public static Map<String, String> uuidCache = syncMap();
     public static Map<String, String> uuidCacheReversed = syncMap();

--- a/src/main/java/net/coreprotect/database/Lookup.java
+++ b/src/main/java/net/coreprotect/database/Lookup.java
@@ -17,6 +17,10 @@ import net.coreprotect.consumer.Queue;
 public class Lookup extends Queue {
 
     public static long countLookupRows(Statement statement, CommandSender user, List<String> checkUuids, List<String> checkUsers, List<Object> restrictList, Map<Object, Boolean> excludeList, List<String> excludeUserList, List<Integer> actionList, Location location, Integer[] radius, Long[] rowData, long startTime, long endTime, boolean restrictWorld, boolean lookup) {
+        return countLookupRows(statement, user, checkUuids, checkUsers, restrictList, excludeList, excludeUserList, actionList, location, radius, rowData, startTime, endTime, restrictWorld, lookup, "");
+    }
+
+    public static long countLookupRows(Statement statement, CommandSender user, List<String> checkUuids, List<String> checkUsers, List<Object> restrictList, Map<Object, Boolean> excludeList, List<String> excludeUserList, List<Integer> actionList, Location location, Integer[] radius, Long[] rowData, long startTime, long endTime, boolean restrictWorld, boolean lookup, String messageFilter) {
         Long rows = 0L;
 
         try {
@@ -25,7 +29,7 @@ public class Lookup extends Queue {
             }
             Consumer.isPaused = true;
 
-            ResultSet results = LookupRaw.rawLookupResultSet(statement, user, checkUuids, checkUsers, restrictList, excludeList, excludeUserList, actionList, location, radius, null, startTime, endTime, -1, -1, restrictWorld, lookup, true);
+            ResultSet results = LookupRaw.rawLookupResultSet(statement, user, checkUuids, checkUsers, restrictList, excludeList, excludeUserList, actionList, location, radius, null, startTime, endTime, -1, -1, restrictWorld, lookup, messageFilter, true);
             while (results.next()) {
                 int resultTable = results.getInt("tbl");
                 long count = results.getLong("count");
@@ -58,10 +62,14 @@ public class Lookup extends Queue {
     }
 
     public static List<String[]> performPartialLookup(Statement statement, CommandSender user, List<String> checkUuids, List<String> checkUsers, List<Object> restrictList, Map<Object, Boolean> excludeList, List<String> excludeUserList, List<Integer> actionList, Location location, Integer[] radius, Long[] rowData, long startTime, long endTime, int limitOffset, int limitCount, boolean restrictWorld, boolean lookup) {
+        return performPartialLookup(statement, user, checkUuids, checkUsers, restrictList, excludeList, excludeUserList, actionList, location, radius, rowData, startTime, endTime, limitOffset, limitCount, restrictWorld, lookup, "");
+    }
+
+    public static List<String[]> performPartialLookup(Statement statement, CommandSender user, List<String> checkUuids, List<String> checkUsers, List<Object> restrictList, Map<Object, Boolean> excludeList, List<String> excludeUserList, List<Integer> actionList, Location location, Integer[] radius, Long[] rowData, long startTime, long endTime, int limitOffset, int limitCount, boolean restrictWorld, boolean lookup, String messageFilter) {
         List<String[]> newList = new ArrayList<>();
 
         try {
-            List<Object[]> lookupList = LookupRaw.performLookupRaw(statement, user, checkUuids, checkUsers, restrictList, excludeList, excludeUserList, actionList, location, radius, rowData, startTime, endTime, limitOffset, limitCount, restrictWorld, lookup);
+            List<Object[]> lookupList = LookupRaw.performLookupRaw(statement, user, checkUuids, checkUsers, restrictList, excludeList, excludeUserList, actionList, location, radius, rowData, startTime, endTime, limitOffset, limitCount, restrictWorld, lookup, messageFilter);
             newList = LookupConverter.convertRawLookup(statement, lookupList);
         }
         catch (Exception e) {

--- a/src/main/java/net/coreprotect/database/LookupRaw.java
+++ b/src/main/java/net/coreprotect/database/LookupRaw.java
@@ -28,6 +28,10 @@ import net.coreprotect.utility.WorldUtils;
 public class LookupRaw extends Queue {
 
     protected static List<Object[]> performLookupRaw(Statement statement, CommandSender user, List<String> checkUuids, List<String> checkUsers, List<Object> restrictList, Map<Object, Boolean> excludeList, List<String> excludeUserList, List<Integer> actionList, Location location, Integer[] radius, Long[] rowData, long startTime, long endTime, int limitOffset, int limitCount, boolean restrictWorld, boolean lookup) {
+        return performLookupRaw(statement, user, checkUuids, checkUsers, restrictList, excludeList, excludeUserList, actionList, location, radius, rowData, startTime, endTime, limitOffset, limitCount, restrictWorld, lookup, "");
+    }
+
+    protected static List<Object[]> performLookupRaw(Statement statement, CommandSender user, List<String> checkUuids, List<String> checkUsers, List<Object> restrictList, Map<Object, Boolean> excludeList, List<String> excludeUserList, List<Integer> actionList, Location location, Integer[] radius, Long[] rowData, long startTime, long endTime, int limitOffset, int limitCount, boolean restrictWorld, boolean lookup, String messageFilter) {
         List<Object[]> list = new ArrayList<>();
         List<Integer> invalidRollbackActions = new ArrayList<>();
         invalidRollbackActions.add(2);
@@ -47,7 +51,7 @@ public class LookupRaw extends Queue {
 
             Consumer.isPaused = true;
 
-            ResultSet results = rawLookupResultSet(statement, user, checkUuids, checkUsers, restrictList, excludeList, excludeUserList, actionList, location, radius, rowData, startTime, endTime, limitOffset, limitCount, restrictWorld, lookup, false);
+            ResultSet results = rawLookupResultSet(statement, user, checkUuids, checkUsers, restrictList, excludeList, excludeUserList, actionList, location, radius, rowData, startTime, endTime, limitOffset, limitCount, restrictWorld, lookup, messageFilter, false);
 
             while (results.next()) {
                 if (actionList.contains(6) || actionList.contains(7)) {
@@ -220,6 +224,10 @@ public class LookupRaw extends Queue {
     }
 
     static ResultSet rawLookupResultSet(Statement statement, CommandSender user, List<String> checkUuids, List<String> checkUsers, List<Object> restrictList, Map<Object, Boolean> excludeList, List<String> excludeUserList, List<Integer> actionList, Location location, Integer[] radius, Long[] rowData, long startTime, long endTime, int limitOffset, int limitCount, boolean restrictWorld, boolean lookup, boolean count) {
+        return rawLookupResultSet(statement, user, checkUuids, checkUsers, restrictList, excludeList, excludeUserList, actionList, location, radius, rowData, startTime, endTime, limitOffset, limitCount, restrictWorld, lookup, "", count);
+    }
+
+    static ResultSet rawLookupResultSet(Statement statement, CommandSender user, List<String> checkUuids, List<String> checkUsers, List<Object> restrictList, Map<Object, Boolean> excludeList, List<String> excludeUserList, List<Integer> actionList, Location location, Integer[] radius, Long[] rowData, long startTime, long endTime, int limitOffset, int limitCount, boolean restrictWorld, boolean lookup, String messageFilter, boolean count) {
         ResultSet results = null;
 
         try {
@@ -517,6 +525,10 @@ public class LookupRaw extends Queue {
 
             if (actionList.contains(10)) {
                 queryBlock = queryBlock + " action = '1' AND (LENGTH(line_1) > 0 OR LENGTH(line_2) > 0 OR LENGTH(line_3) > 0 OR LENGTH(line_4) > 0 OR LENGTH(line_5) > 0 OR LENGTH(line_6) > 0 OR LENGTH(line_7) > 0 OR LENGTH(line_8) > 0) AND";
+            }
+
+            if (messageFilter != null && messageFilter.length() > 0 && (actionList.contains(6) || actionList.contains(7))) {
+                queryBlock = queryBlock + " message LIKE '%" + messageFilter + "%' AND";
             }
 
             if (queryBlock.length() > 0) {


### PR DESCRIPTION
This PR allows for a `message:` param to be added to the lookup command when using the `command` and `chat` actions to filter by a string.

E.g: `/co l Rainnny a:chat message:Hello` - will show all sent messages by Rainnny containing "Hello"