### PR TITLE
Fix dyed bundle rollback for 1.21.2+

### DIFF
--- a/src/main/java/net/coreprotect/bukkit/BukkitAdapter.java
+++ b/src/main/java/net/coreprotect/bukkit/BukkitAdapter.java
@@ -361,6 +361,12 @@ public class BukkitAdapter implements BukkitInterface {
         return false;
     }
 
+
+    @Override
+    public boolean isBundle(Material material) {
+        return false;
+    }
+
     @Override
     public boolean isCopperChest(Material material) {
         return false;

--- a/src/main/java/net/coreprotect/bukkit/BukkitInterface.java
+++ b/src/main/java/net/coreprotect/bukkit/BukkitInterface.java
@@ -152,6 +152,17 @@ public interface BukkitInterface {
      */
     boolean isBookshelfBook(Material material);
 
+
+    /**
+     * Checks if a material is a bundle.
+     * 
+     * @param material
+     *            The material to check
+     * @return true if the material is a bundle, false otherwise
+     */
+    boolean isBundle(Material material);
+
+
     /**
      * Gets the seeds material for a plant material.
      * 

--- a/src/main/java/net/coreprotect/bukkit/Bukkit_v1_17.java
+++ b/src/main/java/net/coreprotect/bukkit/Bukkit_v1_17.java
@@ -153,8 +153,14 @@ public class Bukkit_v1_17 extends BukkitAdapter {
     }
 
     @Override
+    public boolean isBundle(Material material) {
+        return material == Material.BUNDLE;
+    }
+
+
+    @Override
     public boolean setItemMeta(Material rowType, ItemStack itemstack, List<Map<String, Object>> map) {
-        if (rowType == Material.BUNDLE) {
+        if (BukkitAdapter.ADAPTER.isBundle(rowType)) {
             BundleMeta meta = (BundleMeta) itemstack.getItemMeta();
             for (Map<String, Object> itemData : map) {
                 ItemStack itemStack = ItemUtils.unserializeItemStack(itemData);

--- a/src/main/java/net/coreprotect/bukkit/Bukkit_v1_21.java
+++ b/src/main/java/net/coreprotect/bukkit/Bukkit_v1_21.java
@@ -27,6 +27,7 @@ public class Bukkit_v1_21 extends Bukkit_v1_20 {
 
     public static Set<Material> COPPER_CHESTS = new HashSet<>(Arrays.asList());
     public static Set<Material> SHELVES = new HashSet<>(Arrays.asList());
+    public static Set<Material> BUNDLES = new HashSet<>(Arrays.asList());
 
     /**
      * Initializes the Bukkit_v1_21 adapter with 1.21-specific block groups and mappings.
@@ -35,6 +36,7 @@ public class Bukkit_v1_21 extends Bukkit_v1_20 {
     public Bukkit_v1_21() {
         initializeBlockGroups();
         initializeTrapdoorBlocks();
+        initializeBundles();
         BlockGroup.INTERACT_BLOCKS.addAll(copperChestMaterials());
         BlockGroup.CONTAINERS.addAll(copperChestMaterials());
         BlockGroup.UPDATE_STATE.addAll(copperChestMaterials());
@@ -65,6 +67,20 @@ public class Bukkit_v1_21 extends Bukkit_v1_20 {
             // Add to interaction blocks if not already present
             addToBlockGroupIfMissing(value, BlockGroup.INTERACT_BLOCKS);
             addToBlockGroupIfMissing(value, BlockGroup.SAFE_INTERACT_BLOCKS);
+        }
+    }
+
+    /**
+     * Initializes the bundles group to enable the ability to roll back dyed bundles correctly.
+     * It needs to check whether dyed bundles exist because they were added in 1.21.2.
+     */
+    public void initializeBundles(){
+        if (BUNDLES.isEmpty()) {
+            Material bundle = Material.getMaterial("RED_BUNDLE");
+            if (bundle != null) {
+                BUNDLES.addAll(Tag.ITEMS_BUNDLES.getValues());
+            }
+            BUNDLES.add(Material.BUNDLE);
         }
     }
 
@@ -184,6 +200,12 @@ public class Bukkit_v1_21 extends Bukkit_v1_20 {
     public boolean isShelf(Material material) {
         return SHELVES.contains(material);
     }
+
+    @Override
+    public boolean isBundle(Material material) {
+        return Tag.ITEMS_BUNDLES.getValues().contains(material);
+    }
+
 
     @Override
     public Set<Material> copperChestMaterials() {


### PR DESCRIPTION
This Pull request fixes an issue with dyed bundles, added in 1.21.2, not being rolled back correctly.

This was done by adding to the bukkit adapter, since the existing bundle meta was only set up for the 1.17 experimental bundles which weren't dyable.