### PR TITLE
Prevent logging of wind burst explosions and improve BlockExplodeListener (Fixes #830)

### DIFF
--- a/src/main/java/net/coreprotect/bukkit/BukkitAdapter.java
+++ b/src/main/java/net/coreprotect/bukkit/BukkitAdapter.java
@@ -22,6 +22,8 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Event;
+import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.event.block.SignChangeEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerInteractEvent;
@@ -314,6 +316,17 @@ public class BukkitAdapter implements BukkitInterface {
     @Override
     public boolean isWaxed(Sign sign) {
         return false;
+    }
+
+    @Override
+    public boolean shouldLogExplosion(Event event){
+        return true;
+    }
+
+    @Override
+    public Material getExplodedBlock(BlockExplodeEvent event){
+        // accoding to the Bukkit docs this will always return air
+        return event.getBlock().getType();
     }
 
     @Override

--- a/src/main/java/net/coreprotect/bukkit/BukkitInterface.java
+++ b/src/main/java/net/coreprotect/bukkit/BukkitInterface.java
@@ -14,6 +14,8 @@ import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Event;
+import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.event.block.SignChangeEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerInteractEvent;
@@ -412,6 +414,27 @@ public interface BukkitInterface {
      * @return true if the event is for the front side, false otherwise
      */
     boolean isSignFront(SignChangeEvent event);
+
+
+
+    /**
+     * Checks whether an explosion event should be logged or not. (i.e. wind charge explosions)
+     * 
+     * @param event
+     *            The explosion event (Block or Entity ExplodeEvent)
+     * @return true if the explosion should affect blocks
+     */
+    boolean shouldLogExplosion(Event event);
+
+
+    /**
+     * Gets the material of the block that exploded
+     * 
+     * @param event
+     *            The block explosion event
+     * @return the material of the block that caused the explosion
+     */
+    Material getExplodedBlock(BlockExplodeEvent event);
 
     // --------------------------------------------------------------------------
     // Registry methods

--- a/src/main/java/net/coreprotect/bukkit/Bukkit_v1_20.java
+++ b/src/main/java/net/coreprotect/bukkit/Bukkit_v1_20.java
@@ -13,6 +13,7 @@ import org.bukkit.block.ChiseledBookshelf;
 import org.bukkit.block.Sign;
 import org.bukkit.block.sign.Side;
 import org.bukkit.entity.Arrow;
+import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.event.block.SignChangeEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
@@ -296,5 +297,11 @@ public class Bukkit_v1_20 extends Bukkit_v1_19 {
             hasBasePotionType = false;
             return super.getArrowMeta(arrow, itemStack);
         }
+    }
+
+    @Override
+    public Material getExplodedBlock(BlockExplodeEvent event){
+        // accoding to the Bukkit docs this will always return air
+        return event.getExplodedBlockState().getType();
     }
 }

--- a/src/main/java/net/coreprotect/bukkit/Bukkit_v1_21.java
+++ b/src/main/java/net/coreprotect/bukkit/Bukkit_v1_21.java
@@ -6,12 +6,17 @@ import java.util.List;
 import java.util.Set;
 
 import org.bukkit.Bukkit;
+import org.bukkit.ExplosionResult;
 import org.bukkit.Keyed;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Tag;
 import org.bukkit.entity.EntityType;
+import org.bukkit.event.Event;
+import org.bukkit.event.block.BlockExplodeEvent;
+import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.inventory.InventoryType;
+
 
 import net.coreprotect.model.BlockGroup;
 
@@ -217,5 +222,19 @@ public class Bukkit_v1_21 extends Bukkit_v1_20 {
         }
 
         return SHELVES;
+    }
+
+    @Override
+    public boolean shouldLogExplosion(Event event){
+        ExplosionResult result = null;
+
+        if (event instanceof EntityExplodeEvent){
+            result = ((EntityExplodeEvent)event).getExplosionResult();
+        } else if (event instanceof BlockExplodeEvent){
+            result = ((BlockExplodeEvent)event).getExplosionResult();
+        }
+        return !(result == ExplosionResult.KEEP ||
+                 result == ExplosionResult.TRIGGER_BLOCK
+        );
     }
 }

--- a/src/main/java/net/coreprotect/listener/block/BlockExplodeListener.java
+++ b/src/main/java/net/coreprotect/listener/block/BlockExplodeListener.java
@@ -146,18 +146,25 @@ public final class BlockExplodeListener extends Queue implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     protected void onBlockExplode(BlockExplodeEvent event) {
-        Block eventBlock = event.getBlock();
-        World world = eventBlock.getLocation().getWorld();
+        Material eventMaterial = BukkitAdapter.ADAPTER.getExplodedBlock(event);
+        World world = event.getBlock().getLocation().getWorld();
+
+        if (!BukkitAdapter.ADAPTER.shouldLogExplosion(event)){
+            return;
+        }
+
         String user = "";
-        if (!eventBlock.getType().equals(Material.AIR) && !eventBlock.getType().equals(Material.CAVE_AIR)) {
-            user = eventBlock.getType().name().toLowerCase(Locale.ROOT);
+        if (!eventMaterial.equals(Material.AIR) && !eventMaterial.equals(Material.CAVE_AIR)) {
+            user = eventMaterial.name().toLowerCase(Locale.ROOT);
+
+            if (user.contains("respawn_anchor")) {
+                user = "#respawn_anchor";
+            }
+            else if (user.contains("_bed")) {
+                user = "#bed";
+            }
         }
-        if (user.contains("tnt")) {
-            user = "#tnt";
-        }
-        else if (user.contains("end_crystal")) {
-            user = "#end_crystal";
-        }
+        
         if (!user.startsWith("#")) {
             user = "#explosion";
         }

--- a/src/main/java/net/coreprotect/listener/entity/EntityExplodeListener.java
+++ b/src/main/java/net/coreprotect/listener/entity/EntityExplodeListener.java
@@ -1,5 +1,6 @@
 package net.coreprotect.listener.entity;
 
+import org.bukkit.ExplosionResult;
 import org.bukkit.World;
 import org.bukkit.entity.Creeper;
 import org.bukkit.entity.EnderCrystal;
@@ -15,6 +16,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExplodeEvent;
 
+import net.coreprotect.bukkit.BukkitAdapter;
 import net.coreprotect.config.Config;
 import net.coreprotect.consumer.Queue;
 import net.coreprotect.listener.block.BlockExplodeListener;
@@ -24,7 +26,8 @@ public final class EntityExplodeListener extends Queue implements Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     protected void onEntityExplode(EntityExplodeEvent event) {
         Entity entity = event.getEntity();
-        if (entity.getType().name().equals("WIND_CHARGE") || entity.getType().name().equals("BREEZE_WIND_CHARGE")) {
+
+        if (!BukkitAdapter.ADAPTER.shouldLogExplosion(event)){
             return;
         }
 


### PR DESCRIPTION
This PR fixes #830 by using the new [ExplosionResult](https://jd.papermc.io/paper/1.21.11/org/bukkit/ExplosionResult.html) system introduced in 1.21 through the Bukkit adapter

It also improves logging for other BlockExplosions by logging bed and respawn anchor explosions respectively as #bed and #respawn_anchor, reducing the amount of explosions logged as a generic "#explosion". Due to the .getExplodedBlockState() method only being added in 1.20, it also goes through the bukkit adapter.

I have removed the checks for #tnt and #end_crystal in BlockExplodeListener because they only trigger the EntityExplodeListerner anyways, so there was no point in maintaining them.