### PR TITLE
Fix wind charge/add new egg throw logging

### DIFF
--- a/src/main/java/net/coreprotect/listener/player/PlayerInteractListener.java
+++ b/src/main/java/net/coreprotect/listener/player/PlayerInteractListener.java
@@ -1,5 +1,6 @@
 package net.coreprotect.listener.player;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
@@ -595,9 +596,11 @@ public final class PlayerInteractListener extends Queue implements Listener {
             }
 
             if (event.useItemInHand() != Event.Result.DENY) {
-                List<Material> entityBlockTypes = Arrays.asList(Material.ARMOR_STAND, Material.END_CRYSTAL, Material.BOW, Material.CROSSBOW, Material.TRIDENT, Material.EXPERIENCE_BOTTLE, Material.SPLASH_POTION, Material.LINGERING_POTION, Material.ENDER_PEARL, Material.FIREWORK_ROCKET, Material.EGG, Material.SNOWBALL);
+                List<Material> entityBlockTypes = new ArrayList<>(Arrays.asList(Material.ARMOR_STAND, Material.END_CRYSTAL, Material.BOW, Material.CROSSBOW, Material.TRIDENT, Material.EXPERIENCE_BOTTLE, Material.SPLASH_POTION, Material.LINGERING_POTION, Material.ENDER_PEARL, Material.FIREWORK_ROCKET, Material.EGG, Material.SNOWBALL));
                 try {
                     entityBlockTypes.add(Material.valueOf("WIND_CHARGE"));
+                    entityBlockTypes.add(Material.valueOf("BLUE_EGG"));
+                    entityBlockTypes.add(Material.valueOf("BROWN_EGG"));
                 }
                 catch (Exception e) {
                     // not running MC 1.21+

--- a/src/main/java/net/coreprotect/listener/player/ProjectileLaunchListener.java
+++ b/src/main/java/net/coreprotect/listener/player/ProjectileLaunchListener.java
@@ -68,7 +68,7 @@ public final class ProjectileLaunchListener extends Queue implements Listener {
             String name = pair.getKey();
             Object[] data = pair.getValue();
             ItemStack itemStack = (ItemStack) data[3];
-            Material entityMaterial = EntityUtils.getEntityMaterial(event.getEntityType());
+            Material entityMaterial = EntityUtils.getEntityMaterial(event.getEntity());
             boolean isBow = BOWS.contains(itemStack.getType());
             if ((data[1].equals(key) || data[2].equals(key)) && (entityMaterial == itemStack.getType() || (itemStack.getType() == Material.LINGERING_POTION && entityMaterial == Material.SPLASH_POTION) || isBow)) {
                 boolean thrownItem = (itemStack.getType() != Material.FIREWORK_ROCKET && !isBow);

--- a/src/main/java/net/coreprotect/utility/EntityUtils.java
+++ b/src/main/java/net/coreprotect/utility/EntityUtils.java
@@ -3,11 +3,13 @@ package net.coreprotect.utility;
 import java.util.Locale;
 
 import org.bukkit.Material;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 
 import net.coreprotect.bukkit.BukkitAdapter;
 import net.coreprotect.config.ConfigHandler;
 import net.coreprotect.consumer.Queue;
+import org.bukkit.entity.ThrowableProjectile;
 
 public class EntityUtils extends Queue {
 
@@ -48,6 +50,14 @@ public class EntityUtils extends Queue {
         }
 
         return id;
+    }
+
+    public static Material getEntityMaterial(final Entity entity) {
+        if (entity instanceof ThrowableProjectile) {
+            return ((ThrowableProjectile) entity).getItem().getType();
+        }
+
+        return getEntityMaterial(entity.getType());
     }
 
     public static Material getEntityMaterial(EntityType type) {


### PR DESCRIPTION
Closes #861

The list returned by Arrays#asList doesn't implement the add method, so that always ended up throwing and preventing wind charges from being logged as thrown. Also adds the blue & brown eggs to that list, and adds a new utility method that is able to retrieve those egg materials so that the equality check passes.