### PR TITLE
fix: Fix CoreProtect and Slimefun item meta null pointer error 修复CoreProtect与Slimefun物品meta空指针报错

### DIFF
--- a/src/main/java/net/coreprotect/listener/entity/EntityDeathListener.java
+++ b/src/main/java/net/coreprotect/listener/entity/EntityDeathListener.java
@@ -387,7 +387,13 @@ public final class EntityDeathListener extends Queue implements Listener {
                     List<Object> itemMap = new ArrayList<>();
                     ItemStack item = merchantRecipe.getResult().clone();
                     List<List<Map<String, Object>>> metadata = ItemMetaHandler.serialize(item, item.getType(), null, 0);
-                    item.setItemMeta(null);
+                    try {
+                        if (item.hasItemMeta() && item.getItemMeta() != null) {
+                            item.setItemMeta(null);
+                        }
+                    }
+                    catch (Exception ignored) {
+                    }
                     itemMap.add(item.serialize());
                     itemMap.add(metadata);
                     recipe.add(itemMap);
@@ -399,7 +405,13 @@ public final class EntityDeathListener extends Queue implements Listener {
                         itemMap = new ArrayList<>();
                         item = ingredient.clone();
                         metadata = ItemMetaHandler.serialize(item, item.getType(), null, 0);
-                        item.setItemMeta(null);
+                        try {
+                            if (item.hasItemMeta() && item.getItemMeta() != null) {
+                                item.setItemMeta(null);
+                            }
+                        }
+                        catch (Exception ignored) {
+                        }
                         itemMap.add(item.serialize());
                         itemMap.add(metadata);
                         ingredients.add(itemMap);


### PR DESCRIPTION
fix: Fix CoreProtect and Slimefun item meta null pointer error
修复：修复CoreProtect与Slimefun物品meta空指针报错