### PR TITLE
Fix FAWE commands not logged by CoreProtect (#893)

### DIFF
--- a/src/main/java/net/coreprotect/worldedit/CoreProtectLogger.java
+++ b/src/main/java/net/coreprotect/worldedit/CoreProtectLogger.java
@@ -1,5 +1,7 @@
 package net.coreprotect.worldedit;
 
+import java.util.Set;
+
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -88,6 +90,11 @@ public class CoreProtectLogger extends AbstractDelegateExtent {
     }
 
     @Override
+    public <B extends BlockStateHolder<B>> int setBlocks(Region region, B block) throws MaxChangedBlocksException {
+        return this.setBlocks(region, (Pattern) block);
+    }
+
+    @Override
     public int setBlocks(Region region, Pattern pattern) throws MaxChangedBlocksException {
         org.bukkit.World world = BukkitAdapter.adapt(eventWorld);
         if (!Config.getConfig(world).WORLDEDIT) {
@@ -95,6 +102,31 @@ public class CoreProtectLogger extends AbstractDelegateExtent {
         }
         processPatternToBlocks(world, region, pattern);
         return eventExtent.setBlocks(region, pattern);
+    }
+
+    @Override
+    public int setBlocks(Set<BlockVector3> vset, Pattern pattern) {
+        org.bukkit.World world = BukkitAdapter.adapt(eventWorld);
+        if (!Config.getConfig(world).WORLDEDIT) {
+            return eventExtent.setBlocks(vset, pattern);
+        }
+        processPatternToBlocks(world, vset, pattern);
+        return eventExtent.setBlocks(vset, pattern);
+    }
+
+    private void processPatternToBlocks(org.bukkit.World world, Set<BlockVector3> vset, Pattern pattern) {
+        for (BlockVector3 position : vset) {
+            BlockState oldBlock = eventExtent.getBlock(position);
+            Material oldType = BukkitAdapter.adapt(oldBlock.getBlockType());
+            Location location = new Location(world, position.getBlockX(), position.getBlockY(), position.getBlockZ());
+            BaseBlock baseBlock = WorldEditLogger.getBaseBlock(eventExtent, position, location, oldType, oldBlock);
+
+            // No clear way to get container content data from within the WorldEdit API
+            // Data may be available by converting oldBlock.toBaseBlock().getNbtData()
+            // e.g. BaseBlock block = eventWorld.getBlock(position);
+            ItemStack[] containerData = CoreProtectEditSessionEvent.isFAWE() ? null : ItemUtils.getContainerContents(oldType, null, location);
+            WorldEditLogger.postProcess(eventExtent, eventActor, position, location, pattern.applyBlock(position), baseBlock, oldType, oldBlock, containerData);
+        }
     }
 
     private void processPatternToBlocks(org.bukkit.World world, Region region, Pattern pattern) {


### PR DESCRIPTION
## Summary

Fixes #893 — Certain FAWE commands (`//line`, `//walls`, `//removeabove`, `//removebelow`) were not being logged by CoreProtect and could not be rolled back.

## Root Cause

`CoreProtectLogger` extends `AbstractDelegateExtent` and intercepts block writes via overridden methods. However, two method overloads were missing, causing FAWE to bypass the logging path entirely:

| Commands | FAWE Call Path | Issue |
|---|---|---|
| `//line`, `//walls` | `drawLine()` / `makeCuboidWalls()` → `setBlocks(Set<BlockVector3>, Pattern)` | Not overridden — logging skipped |
| `//removeabove`, `//removebelow` | `setBlocks(region, BlockTypes.AIR.getDefaultState())` → Java resolves to `setBlocks(Region, B extends BlockStateHolder<B>)` as the more specific overload | Not overridden — logging skipped |

## Changes

**`CoreProtectLogger.java`**

- Added `setBlocks(Region, B extends BlockStateHolder<B>)` override — since `BlockStateHolder<B>` extends `Pattern`, this simply casts and delegates to the already-overridden `setBlocks(Region, Pattern)`, restoring logging for `//removeabove` and `//removebelow`.
- Added `setBlocks(Set<BlockVector3>, Pattern)` override — iterates over the provided `Set<BlockVector3>`, reads the old block state for each position, and calls `WorldEditLogger.postProcess()` before delegating to the underlying extent, restoring logging for `//line` and `//walls`.
- Added `processPatternToBlocks(World, Set<BlockVector3>, Pattern)` private helper, consistent with the existing `processPatternToBlocks(World, Region, Pattern)` method.
