### PR TITLE
Fix incorrect block logging for FAWE replaceBlocks (#624)

### DIFF
--- a/src/main/java/net/coreprotect/worldedit/CoreProtectLogger.java
+++ b/src/main/java/net/coreprotect/worldedit/CoreProtectLogger.java
@@ -83,7 +83,7 @@ public class CoreProtectLogger extends AbstractDelegateExtent {
         if (!Config.getConfig(world).WORLDEDIT) {
             return eventExtent.replaceBlocks(region, mask, pattern);
         }
-        processPatternToBlocks(world, region, pattern);
+        processPatternToBlocks(world, region, mask, pattern);
         return eventExtent.replaceBlocks(region, mask, pattern);
     }
 
@@ -95,6 +95,24 @@ public class CoreProtectLogger extends AbstractDelegateExtent {
         }
         processPatternToBlocks(world, region, pattern);
         return eventExtent.setBlocks(region, pattern);
+    }
+
+    private void processPatternToBlocks(org.bukkit.World world, Region region, Mask mask, Pattern pattern) {
+        for (BlockVector3 position : region.clone()) {
+            if (!mask.test(position)) {
+                continue;
+            }
+            BlockState oldBlock = eventExtent.getBlock(position);
+            Material oldType = BukkitAdapter.adapt(oldBlock.getBlockType());
+            Location location = new Location(world, position.getBlockX(), position.getBlockY(), position.getBlockZ());
+            BaseBlock baseBlock = WorldEditLogger.getBaseBlock(eventExtent, position, location, oldType, oldBlock);
+
+            // No clear way to get container content data from within the WorldEdit API
+            // Data may be available by converting oldBlock.toBaseBlock().getNbtData()
+            // e.g. BaseBlock block = eventWorld.getBlock(position);
+            ItemStack[] containerData = CoreProtectEditSessionEvent.isFAWE() ? null : ItemUtils.getContainerContents(oldType, null, location);
+            WorldEditLogger.postProcess(eventExtent, eventActor, position, location, pattern.applyBlock(position), baseBlock, oldType, oldBlock, containerData);
+        }
     }
 
     private void processPatternToBlocks(org.bukkit.World world, Region region, Pattern pattern) {

--- a/src/main/java/net/coreprotect/worldedit/CoreProtectLogger.java
+++ b/src/main/java/net/coreprotect/worldedit/CoreProtectLogger.java
@@ -1,5 +1,7 @@
 package net.coreprotect.worldedit;
 
+import java.util.Set;
+
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -88,6 +90,11 @@ public class CoreProtectLogger extends AbstractDelegateExtent {
     }
 
     @Override
+    public <B extends BlockStateHolder<B>> int setBlocks(Region region, B block) throws MaxChangedBlocksException {
+        return this.setBlocks(region, (Pattern) block);
+    }
+
+    @Override
     public int setBlocks(Region region, Pattern pattern) throws MaxChangedBlocksException {
         org.bukkit.World world = BukkitAdapter.adapt(eventWorld);
         if (!Config.getConfig(world).WORLDEDIT) {
@@ -95,6 +102,31 @@ public class CoreProtectLogger extends AbstractDelegateExtent {
         }
         processPatternToBlocks(world, region, pattern);
         return eventExtent.setBlocks(region, pattern);
+    }
+
+    @Override
+    public int setBlocks(Set<BlockVector3> vset, Pattern pattern) {
+        org.bukkit.World world = BukkitAdapter.adapt(eventWorld);
+        if (!Config.getConfig(world).WORLDEDIT) {
+            return eventExtent.setBlocks(vset, pattern);
+        }
+        processPatternToBlocks(world, vset, pattern);
+        return eventExtent.setBlocks(vset, pattern);
+    }
+
+    private void processPatternToBlocks(org.bukkit.World world, Set<BlockVector3> vset, Pattern pattern) {
+        for (BlockVector3 position : vset) {
+            BlockState oldBlock = eventExtent.getBlock(position);
+            Material oldType = BukkitAdapter.adapt(oldBlock.getBlockType());
+            Location location = new Location(world, position.getBlockX(), position.getBlockY(), position.getBlockZ());
+            BaseBlock baseBlock = WorldEditLogger.getBaseBlock(eventExtent, position, location, oldType, oldBlock);
+
+            // No clear way to get container content data from within the WorldEdit API
+            // Data may be available by converting oldBlock.toBaseBlock().getNbtData()
+            // e.g. BaseBlock block = eventWorld.getBlock(position);
+            ItemStack[] containerData = CoreProtectEditSessionEvent.isFAWE() ? null : ItemUtils.getContainerContents(oldType, null, location);
+            WorldEditLogger.postProcess(eventExtent, eventActor, position, location, pattern.applyBlock(position), baseBlock, oldType, oldBlock, containerData);
+        }
     }
 
     private void processPatternToBlocks(org.bukkit.World world, Region region, Mask mask, Pattern pattern) {


### PR DESCRIPTION
## Summary

Fixes #624 — When using `//replace` with FAWE, CoreProtect was logging block changes
for every block in the selected region, including blocks that did not match the mask
(e.g. air blocks being logged as having stone placed in them).

## Root Cause

`replaceBlocks(Region, Mask, Pattern)` called `processPatternToBlocks` without
passing the `Mask` parameter:

```java
// Before (incorrect)
processPatternToBlocks(world, region, pattern); // mask ignored
return eventExtent.replaceBlocks(region, mask, pattern);
```

This caused `processPatternToBlocks` to iterate over every position in the region
and log a block change regardless of whether that position matched the mask.
Meanwhile, `eventExtent.replaceBlocks` correctly applied the mask, so the actual
world changes were accurate — only the CoreProtect log was wrong.

## Fix

Added a `processPatternToBlocks(World, Region, Mask, Pattern)` overload that skips
positions where `mask.test(position)` returns `false`, and updated `replaceBlocks`
to use it:

```java
// After (correct)
processPatternToBlocks(world, region, mask, pattern);
return eventExtent.replaceBlocks(region, mask, pattern);
```

## Changes

**`CoreProtectLogger.java`**

- Updated `replaceBlocks` to pass `mask` to `processPatternToBlocks`
- Added `processPatternToBlocks(World, Region, Mask, Pattern)` private overload
  with a `mask.test(position)` guard to skip non-matching blocks