### PR TITLE
Set prefer_column_name_to_alias on ClickHouse connections

### DIFF
--- a/src/main/java/net/coreprotect/database/clickhouse/ClickHouseJdbcConfig.java
+++ b/src/main/java/net/coreprotect/database/clickhouse/ClickHouseJdbcConfig.java
@@ -46,6 +46,7 @@ public final class ClickHouseJdbcConfig {
         properties.setProperty(SERVER_SETTING_PREFIX + "async_insert", "0");
         properties.setProperty(SERVER_SETTING_PREFIX + "do_not_merge_across_partitions_select_final", "1");
         properties.setProperty(SERVER_SETTING_PREFIX + "wait_end_of_query", "1");
+        properties.setProperty(SERVER_SETTING_PREFIX + "prefer_column_name_to_alias", "1");
         properties.setProperty("ssl", Boolean.toString(tls));
         properties.setProperty("jdbc_ignore_unsupported_values", "false");
     }


### PR DESCRIPTION
Fixes #947.

ClickHouse resolves identifiers to select-list aliases before table columns by default (`prefer_column_name_to_alias = 0`), so lookup queries that reuse a real column name as an alias mis-resolve. The item lookup builds `... data as metadata, 0 as data ... FROM co_item`, where `data` in `data as metadata` binds to the `0 as data` alias instead of the column:

```sql
SELECT toTypeName(metadata) FROM (SELECT data as metadata, 0 as data FROM co_item LIMIT 1)
-- UInt8 (should be Array(Int8))
```

Standalone item lookups return `metadata` as the literal `0`; mixed lookup unions end up as `Variant(Array(Int8), UInt8)` on ClickHouse 26.x. Either way the JDBC client throws `Column is not of array type` in `DatabaseUtils.getBytes` and every `/co lookup` / `/co inspect` touching item rows returns nothing (details and full stack trace in #947).

This sets `prefer_column_name_to_alias = 1` on the connection, which makes ClickHouse resolve columns first — the same semantics SQLite and MySQL give these queries. I audited the generated queries for the inverse hazard (a query needing the alias where a real column with that name exists) and found none: the setting only changes resolution when both an alias and a column share a name, and the only such collision is the `data` one this fixes.

Running in production on two servers (ClickHouse 26.7.1, ~85M events) since 2026-08-09: item metadata comes back as the correct blobs, mixed unions unify to `Array(Int8)`, and lookups work again. The `WHERE notEmpty(data)`-style mis-resolutions on shadowed columns are fixed by the same setting.
