### PR TITLE
Avoid unnecessary regex compilation in hot paths

### DIFF
--- a/src/main/java/net/coreprotect/config/Config.java
+++ b/src/main/java/net/coreprotect/config/Config.java
@@ -14,6 +14,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.regex.Pattern;
 
 import org.bukkit.Bukkit;
 import org.bukkit.World;
@@ -30,6 +31,7 @@ public class Config extends Language {
     private static final Map<String, String> DEFAULT_VALUES = new LinkedHashMap<>();
     private static final Map<String, Config> CONFIG_BY_WORLD_NAME = new HashMap<>();
     private static final String DEFAULT_FILE_HEADER = "# CoreProtect Config";
+    private static final Pattern NON_DIGIT_PATTERN = Pattern.compile("[^0-9]");
     public static final String LINE_SEPARATOR = "\n";
 
     private static final Config GLOBAL = new Config();
@@ -370,7 +372,7 @@ public class Config extends Language {
             return dfl;
         }
 
-        configured = configured.replaceAll("[^0-9]", "");
+        configured = NON_DIGIT_PATTERN.matcher(configured).replaceAll("");
 
         return configured.isEmpty() ? dfl : Integer.parseInt(configured);
     }

--- a/src/main/java/net/coreprotect/database/logger/BlockBreakLogger.java
+++ b/src/main/java/net/coreprotect/database/logger/BlockBreakLogger.java
@@ -63,7 +63,7 @@ public class BlockBreakLogger {
             }
 
             if (checkType == Material.LECTERN && blockData != null) {
-                blockData = blockData.replaceFirst("has_book=true", "has_book=false");
+                blockData = blockData.replace("has_book=true", "has_book=false");
             }
             else if (checkType != null && (checkType == Material.PAINTING || BukkitAdapter.ADAPTER.isItemFrame(checkType))) {
                 blockData = overrideData;


### PR DESCRIPTION
## Description

Two small optimizations to avoid unnecessary regex pattern compilation on frequently-called methods.

### 1. `BlockBreakLogger.log()` — replace `replaceFirst` with `replace`

The lectern block data adjustment uses `String.replaceFirst("has_book=true", "has_book=false")`, which internally compiles a `Pattern` on every invocation. Since the search string is a literal (no regex metacharacters) and appears at most once in a BlockData string, `String.replace(CharSequence, CharSequence)` is functionally identical and avoids the pattern compilation.

This method is called for every block break on the server, which is one of the highest-frequency events CoreProtect logs.

**Change:** `replaceFirst` → `replace` (1 character).

### 2. `Config.getInt()` — cache the digit-strip pattern

`getInt()` calls `configured.replaceAll("[^0-9]", "")` on every integer config read. Each call recompiles the regex. Extracting the pattern to a `private static final Pattern` field eliminates repeated compilation.

**Change:** Added `NON_DIGIT_PATTERN` static field and updated the call site to use it.
