### PR TITLE
Fix ClickHouse lookup pagination for UNION queries

### DIFF
--- a/src/main/java/net/coreprotect/command/lookup/StandardLookupThread.java
+++ b/src/main/java/net/coreprotect/command/lookup/StandardLookupThread.java
@@ -319,6 +319,9 @@ public class StandardLookupThread implements Runnable {
                         List<String[]> lookupList = lookupPage == null
                                 ? Lookup.performPartialLookup(statement, player, uuidList, userList, blockList, excludedBlocks, excludedUsers, actions, entityActionFilter, messageFilters, entityContext, finalLocation, radius, rowData, timeStart, timeEnd, (int) pageStart, displayResults, restrict_world, true, entityContainerId, rollbackState)
                                 : lookupPage.getRows();
+                        if (lookupList == null) {
+                            return;
+                        }
 
                         Map<Integer, EntitySpawnRecord> entitySpawnRecords = Collections.emptyMap();
                         Map<UUID, Location> loadedEntityLocations = Collections.emptyMap();

--- a/src/main/java/net/coreprotect/database/LookupRaw.java
+++ b/src/main/java/net/coreprotect/database/LookupRaw.java
@@ -174,6 +174,25 @@ public class LookupRaw extends Queue {
                 paused = true;
             }
 
+            if (ConfigHandler.databaseType.isClickHouse() && pageRows == null && limitOffset >= 0 && limitCount > 0) {
+                pageRows = new HashMap<>();
+                try (ResultSet pageResults = rawLookupResultSet(statement, user, checkUuids, checkUsers, restrictList, excludeList, excludeUserList, actionList, entityActionFilter, messageFilters, entityContext, location, radius, rowData, startTime, endTime, limitOffset, limitCount, restrictWorld, lookup, false, entityContainerId, false, false, false, rollbackState, null, true)) {
+                    if (pageResults == null) {
+                        return null;
+                    }
+                    while (pageResults.next()) {
+                        int source = pageResults.getInt("tbl");
+                        long rowId = pageResults.getLong("id");
+                        pageRows.computeIfAbsent(source, ignored -> new ArrayList<>()).add(rowId);
+                    }
+                }
+                if (pageRows.isEmpty()) {
+                    return list;
+                }
+                limitOffset = -1;
+                limitCount = -1;
+            }
+
             ResultSet results = rawLookupResultSet(statement, user, checkUuids, checkUsers, restrictList, excludeList, excludeUserList, actionList, entityActionFilter, messageFilters, entityContext, location, radius, rowData, startTime, endTime, limitOffset, limitCount, restrictWorld, lookup, false, entityContainerId, false, false, false, rollbackState, pageRows, false);
             if (results == null) {
                 return null;
@@ -1148,13 +1167,23 @@ public class LookupRaw extends Queue {
             }
 
             if (selectPageRows) {
-                query = buildDuckDBPageQuery(query, entityLocationCte, pageOffset, limitCount, knownTotalRows, cursor, queryOrder.contains("time DESC"));
+                if (ConfigHandler.databaseType.isClickHouse()) {
+                    query = buildClickHousePageQuery(query, queryOrder, limitOffset, limitCount);
+                }
+                else {
+                    query = buildDuckDBPageQuery(query, entityLocationCte, pageOffset, limitCount, knownTotalRows, cursor, queryOrder.contains("time DESC"));
+                }
             }
             else if (summary) {
                 query = buildSummaryQuery(query, inventoryQuery, countGroups, includeGroupCount, limitOffset, limitCount);
             }
             else {
-                query = query + queryOrder + queryLimit + "";
+                if (ConfigHandler.databaseType.isClickHouse() && query.contains(" UNION ALL ")) {
+                    query = "SELECT * FROM (" + query + ") AS coreprotectLookupUnion" + queryOrder + queryLimit;
+                }
+                else {
+                    query = query + queryOrder + queryLimit;
+                }
             }
             if (!selectPageRows && !entityLocationCte.isEmpty()) {
                 query = "WITH " + entityLocationCte + " " + query;
@@ -1337,6 +1366,18 @@ public class LookupRaw extends Queue {
             query.append(" LIMIT ").append(limit).append(" OFFSET ").append(offset);
         }
         return query.toString();
+    }
+
+    private static String buildClickHousePageQuery(String sourceQuery, String queryOrder, int offset, int limit) {
+        if (limit <= 0) {
+            throw new IllegalArgumentException("ClickHouse lookup page size must be positive");
+        }
+        if (offset < 0) {
+            throw new IllegalArgumentException("ClickHouse lookup page offset must not be negative");
+        }
+        String candidateOrder = queryOrder.replace("rowid", "id");
+        return "SELECT tbl,id FROM (" + sourceQuery + ") AS coreprotectLookupCandidates"
+                + candidateOrder + " LIMIT " + limit + " OFFSET " + offset;
     }
 
     private static String buildRollbackPredicate(LookupRollbackState rollbackState, boolean inventoryRollback) {


### PR DESCRIPTION
## Summary

- Paginate ClickHouse union lookups globally instead of limiting only one union branch.
- Use a two-phase lookup so deep pages select lightweight row keys before loading binary payload columns.
- Stop processing cleanly when a lookup query fails instead of triggering a secondary null-pointer exception.

## Problem

ClickHouse lookups that combine multiple event families append pagination directly after a multi-branch `UNION ALL`. The trailing `LIMIT` does not constrain the complete union, so a lookup configured for a few lines can return thousands of rows and flood the Minecraft client chat.

Applying an outer `ORDER BY ... LIMIT ... OFFSET ...` directly to the full rows fixes the result count but makes deep pages materialize large item/container payload expressions before pagination. On large histories this can exceed the ClickHouse memory limit.

## Fix

For paginated ClickHouse detail lookups:

1. Query only `tbl`, `id`, and `time` across the candidate sources and apply global ordering/pagination.
2. Load complete rows only for the selected source/row IDs.

This keeps pagination global while avoiding materialization of binary payloads for discarded rows. Non-ClickHouse lookup paths are unchanged.

## Verification

- `mvn verify` (`BUILD SUCCESS`; tests are skipped by the upstream Maven configuration)
- Reproduced the original excessive result output with a multi-family ClickHouse lookup
- Verified the initial global-limit fix caps output to the requested page size