### PR TITLE
Fix item names not showing for items using the item_name component

### DIFF
--- a/src/main/java/net/coreprotect/utility/ItemUtils.java
+++ b/src/main/java/net/coreprotect/utility/ItemUtils.java
@@ -2,6 +2,7 @@ package net.coreprotect.utility;
 
 import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Array;
+import java.lang.reflect.Method;
 import java.util.*;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -691,7 +692,8 @@ public class ItemUtils {
         var item = getItemStack(metadata, type, amount);
         if (item == null) return "";
 
-        String displayName = item.hasItemMeta() && item.getItemMeta().hasDisplayName() ? item.getItemMeta().getDisplayName() : "";
+        ItemMeta itemMeta = item.hasItemMeta() ? item.getItemMeta() : null;
+        String displayName = itemMeta == null ? "" : getItemDisplayName(itemMeta);
         StringBuilder message = new StringBuilder(Color.ITALIC + displayName + Color.GREY);
 
         List<String> enchantments = ItemMetaHandler.getEnchantments(item, displayName);
@@ -711,6 +713,27 @@ public class ItemUtils {
         }
 
         return message.toString();
+    }
+
+    private static String getItemDisplayName(ItemMeta itemMeta) {
+        try {
+            if (itemMeta.hasDisplayName()) {
+                return itemMeta.getDisplayName();
+            }
+
+            // The item_name component only exists on 1.20.5+, so access it reflectively.
+            Method hasItemName = itemMeta.getClass().getMethod("hasItemName");
+            if (Boolean.TRUE.equals(hasItemName.invoke(itemMeta))) {
+                Method getItemName = itemMeta.getClass().getMethod("getItemName");
+                Object name = getItemName.invoke(itemMeta);
+                return name == null ? "" : (String) name;
+            }
+        }
+        catch (Exception e) {
+            // item_name is not supported on this server version
+        }
+
+        return "";
     }
 
     public static Map<Integer, Object> serializeItemStackLegacy(ItemStack itemStack, String faceData, int slot) {


### PR DESCRIPTION
Items that store their name in the item_name data component (Minecraft 1.20.5+) showed only the material name (e.g. "Netherite Axe") in lookup tooltips, since CoreProtect only read ItemMeta#getDisplayName().

getEnchantments() now falls back to hasItemName()/getItemName() via reflection so custom names display correctly on 1.20.5+ while remaining compatible with older server versions.