### PR TITLE
Fix 30-second shutdown delay on Folia

### DIFF
--- a/src/main/java/net/coreprotect/utility/EntitySpawnTracking.java
+++ b/src/main/java/net/coreprotect/utility/EntitySpawnTracking.java
@@ -736,7 +736,9 @@ public final class EntitySpawnTracking {
                     continue;
                 }
 
-                if (ConfigHandler.isFolia) {
+                // Folia grants the shutdown thread entity ownership after region ticking stops.
+                // Checkpoint owned entities directly: a newly scheduled task may never run during shutdown.
+                if (ConfigHandler.isFolia && !PaperAdapter.ADAPTER.isOwnedByCurrentRegion(entity)) {
                     completion = new CompletableFuture<>();
                     pending.add(completion);
                     CompletableFuture<Void> entityCompletion = completion;


### PR DESCRIPTION
With entity spawn tracking enabled, shutting down a Luminol server consistently took an extra 30 seconds. The logs pointed to `queueLoadedLocationsForShutdown()`, which timed out before the database queue finished draining about a second later.

Folia stops region ticking before disabling plugins. The entity scheduler can still accept a task at that point, but it won't get another tick to run it. CoreProtect then waits for the full 30-second timeout.

The shutdown thread already has permission to access these entities through Folia's ownership check. This change checks that first and saves the current location directly when allowed. Entities owned by another thread still use the existing scheduler path.