### PR TITLE
feat(api): add material filters to typed lookups

### DIFF
--- a/docs/api/version/v13.md
+++ b/docs/api/version/v13.md
@@ -10,6 +10,7 @@ API version 13 adds entity-spawn lookup support while retaining all API version 
 
 ## Upgrading from API v12
 
+- `LookupOptions` supports material inclusion/exclusion filters for typed container, item, and inventory lookups.
 - Added `CoreProtectAction.ENTITY_SPAWN` with action ID `13`.
 - Added `CoreProtectPreLogEvent.Action.ENTITY_SPAWN`.
 - `BlockResult#getEntityType()` recognizes entity-spawn results.

--- a/src/main/java/net/coreprotect/api/BlockAPI.java
+++ b/src/main/java/net/coreprotect/api/BlockAPI.java
@@ -233,8 +233,10 @@ public class BlockAPI {
             try {
                 StringBuilder containerWhere = new StringBuilder();
                 filter.appendWhere(containerWhere, "container_rows");
+                filter.appendMaterialWhere(containerWhere, "container_rows");
                 StringBuilder entityWhere = new StringBuilder();
                 filter.appendEntityContainerWhere(entityWhere, "entity_rows", "spawn_rows");
+                filter.appendMaterialWhere(entityWhere, "entity_rows");
 
                 StringBuilder query = new StringBuilder("SELECT * FROM (");
                 query.append("SELECT 0 AS source,container_rows.rowid AS id,container_rows.time,container_rows.").append(ConfigHandler.databaseType.getUserColumn()).append(",container_rows.wid,container_rows.x,container_rows.y,container_rows.z,container_rows.action,container_rows.type,container_rows.data,container_rows.amount,container_rows.metadata,container_rows.rolled_back FROM ")

--- a/src/main/java/net/coreprotect/api/InventoryAPI.java
+++ b/src/main/java/net/coreprotect/api/InventoryAPI.java
@@ -51,12 +51,15 @@ public class InventoryAPI {
             try {
                 StringBuilder whereBuilder = new StringBuilder();
                 filter.appendWhere(whereBuilder);
+                StringBuilder blockWhereBuilder = new StringBuilder(whereBuilder);
+                filter.appendMaterialWhere(blockWhereBuilder, "", true);
                 filter.appendMaterialWhere(whereBuilder);
                 String where = whereBuilder.toString();
                 StringBuilder entityWhereBuilder = new StringBuilder();
                 filter.appendEntityContainerWhere(entityWhereBuilder, "entity_rows", "spawn_rows");
                 filter.appendMaterialWhere(entityWhereBuilder, "entity_rows");
                 String query = buildQuery(
+                        blockWhereBuilder.toString(),
                         where,
                         entityWhereBuilder.toString(),
                         options.hasLimit(),
@@ -94,10 +97,10 @@ public class InventoryAPI {
         return result;
     }
 
-    private static String buildQuery(String where, String entityWhere, boolean hasLimit, String blockTable, String containerTable, String entityContainerTable, String itemTable) {
+    private static String buildQuery(String blockWhere, String where, String entityWhere, boolean hasLimit, String blockTable, String containerTable, String entityContainerTable, String itemTable) {
         StringBuilder query = new StringBuilder("SELECT * FROM (");
         query.append("SELECT 0 AS source,rowid AS id,time,").append(ConfigHandler.databaseType.getUserColumn()).append(",wid,x,y,z,type,data,1 AS amount,meta AS metadata,action,rolled_back FROM ")
-                .append(blockTable).append(' ').append(where).append(" AND action = 1");
+                .append(blockTable).append(' ').append(blockWhere).append(" AND action = 1");
         query.append(" UNION ALL ");
         query.append("SELECT 1 AS source,rowid AS id,time,").append(ConfigHandler.databaseType.getUserColumn()).append(",wid,x,y,z,type,data,amount,metadata,action,rolled_back FROM ")
                 .append(containerTable).append(' ').append(where);

--- a/src/main/java/net/coreprotect/api/InventoryAPI.java
+++ b/src/main/java/net/coreprotect/api/InventoryAPI.java
@@ -51,9 +51,11 @@ public class InventoryAPI {
             try {
                 StringBuilder whereBuilder = new StringBuilder();
                 filter.appendWhere(whereBuilder);
+                filter.appendMaterialWhere(whereBuilder);
                 String where = whereBuilder.toString();
                 StringBuilder entityWhereBuilder = new StringBuilder();
                 filter.appendEntityContainerWhere(entityWhereBuilder, "entity_rows", "spawn_rows");
+                filter.appendMaterialWhere(entityWhereBuilder, "entity_rows");
                 String query = buildQuery(
                         where,
                         entityWhereBuilder.toString(),

--- a/src/main/java/net/coreprotect/api/ItemAPI.java
+++ b/src/main/java/net/coreprotect/api/ItemAPI.java
@@ -48,6 +48,7 @@ public class ItemAPI {
                 query.append(WorldUtils.getWidIndex("item"));
             }
             filter.appendWhere(query);
+            filter.appendMaterialWhere(query);
             query.append(" AND action NOT IN (")
                     .append(ItemLogger.ITEM_BREAK).append(",")
                     .append(ItemLogger.ITEM_DESTROY).append(",")

--- a/src/main/java/net/coreprotect/api/LookupFilter.java
+++ b/src/main/java/net/coreprotect/api/LookupFilter.java
@@ -6,12 +6,16 @@ import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.StringJoiner;
 
 import org.bukkit.Location;
+import org.bukkit.Material;
 
+import net.coreprotect.bukkit.BukkitAdapter;
 import net.coreprotect.config.ConfigHandler;
 import net.coreprotect.database.DuckDBLookupQuery;
 import net.coreprotect.database.DuckDBSpatialIndex;
+import net.coreprotect.utility.MaterialUtils;
 import net.coreprotect.utility.WorldUtils;
 
 final class LookupFilter {
@@ -21,14 +25,18 @@ final class LookupFilter {
     private final int radius;
     private final int limitOffset;
     private final int limitCount;
+    private final String includeMaterialIds;
+    private final String excludeMaterialIds;
 
-    private LookupFilter(Integer userId, int checkTime, Location location, int radius, int limitOffset, int limitCount) {
+    private LookupFilter(Integer userId, int checkTime, Location location, int radius, int limitOffset, int limitCount, String includeMaterialIds, String excludeMaterialIds) {
         this.userId = userId;
         this.checkTime = checkTime;
         this.location = location;
         this.radius = radius;
         this.limitOffset = limitOffset;
         this.limitCount = limitCount;
+        this.includeMaterialIds = includeMaterialIds;
+        this.excludeMaterialIds = excludeMaterialIds;
     }
 
     static LookupFilter fromOptions(Connection connection, LookupOptions options) throws Exception {
@@ -42,7 +50,8 @@ final class LookupFilter {
             checkTime = (int) (System.currentTimeMillis() / 1000L) - options.getTime();
         }
 
-        return new LookupFilter(userId, checkTime, options.getLocation(), options.getRadius(), options.getLimitOffset(), options.getLimitCount());
+        return new LookupFilter(userId, checkTime, options.getLocation(), options.getRadius(), options.getLimitOffset(), options.getLimitCount(),
+                materialIds(options.getIncludeMaterials()), materialIds(options.getExcludeMaterials()));
     }
 
     boolean hasInvalidUser() {
@@ -127,6 +136,20 @@ final class LookupFilter {
             query.append(" AND ").append(entity).append("x >= ? AND ").append(entity).append("x < ? AND ").append(entity).append("y >= ? AND ").append(entity).append("y < ? AND ").append(entity).append("z >= ? AND ").append(entity).append("z < ?");
         }
         query.append("))");
+    }
+
+    void appendMaterialWhere(StringBuilder query) {
+        appendMaterialWhere(query, "");
+    }
+
+    void appendMaterialWhere(StringBuilder query, String alias) {
+        String qualifier = alias.isEmpty() ? "" : alias + ".";
+        if (!includeMaterialIds.isEmpty()) {
+            query.append(" AND ").append(qualifier).append("type IN (").append(includeMaterialIds).append(")");
+        }
+        if (!excludeMaterialIds.isEmpty()) {
+            query.append(" AND ").append(qualifier).append("type NOT IN (").append(excludeMaterialIds).append(")");
+        }
     }
 
     String table(Connection connection, String table, String alias) {
@@ -295,6 +318,18 @@ final class LookupFilter {
             statement.setLong(parameterIndex++, (long) z + 1L);
         }
         return parameterIndex;
+    }
+
+    private static String materialIds(List<Material> materials) {
+        StringJoiner result = new StringJoiner(",");
+        for (Material material : materials) {
+            result.add(String.valueOf(MaterialUtils.getBlockId(material.name(), false)));
+            int legacyId = BukkitAdapter.ADAPTER.getLegacyBlockId(material);
+            if (legacyId > 0) {
+                result.add(String.valueOf(legacyId));
+            }
+        }
+        return result.toString();
     }
 
     private static String alias(String alias) {

--- a/src/main/java/net/coreprotect/api/LookupFilter.java
+++ b/src/main/java/net/coreprotect/api/LookupFilter.java
@@ -5,16 +5,18 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.StringJoiner;
 
 import org.bukkit.Location;
 import org.bukkit.Material;
 
-import net.coreprotect.bukkit.BukkitAdapter;
 import net.coreprotect.config.ConfigHandler;
 import net.coreprotect.database.DuckDBLookupQuery;
 import net.coreprotect.database.DuckDBSpatialIndex;
+import net.coreprotect.utility.ItemUtils;
 import net.coreprotect.utility.MaterialUtils;
 import net.coreprotect.utility.WorldUtils;
 
@@ -25,18 +27,20 @@ final class LookupFilter {
     private final int radius;
     private final int limitOffset;
     private final int limitCount;
-    private final String includeMaterialIds;
-    private final String excludeMaterialIds;
+    private final List<Material> includeMaterials;
+    private final List<Material> excludeMaterials;
+    private final Map<Integer, Material> materialTypes;
 
-    private LookupFilter(Integer userId, int checkTime, Location location, int radius, int limitOffset, int limitCount, String includeMaterialIds, String excludeMaterialIds) {
+    private LookupFilter(Integer userId, int checkTime, Location location, int radius, int limitOffset, int limitCount, List<Material> includeMaterials, List<Material> excludeMaterials, Map<Integer, Material> materialTypes) {
         this.userId = userId;
         this.checkTime = checkTime;
         this.location = location;
         this.radius = radius;
         this.limitOffset = limitOffset;
         this.limitCount = limitCount;
-        this.includeMaterialIds = includeMaterialIds;
-        this.excludeMaterialIds = excludeMaterialIds;
+        this.includeMaterials = includeMaterials;
+        this.excludeMaterials = excludeMaterials;
+        this.materialTypes = materialTypes;
     }
 
     static LookupFilter fromOptions(Connection connection, LookupOptions options) throws Exception {
@@ -50,8 +54,18 @@ final class LookupFilter {
             checkTime = (int) (System.currentTimeMillis() / 1000L) - options.getTime();
         }
 
+        Map<Integer, Material> materialTypes = new HashMap<>();
+        if (!options.getIncludeMaterials().isEmpty() || !options.getExcludeMaterials().isEmpty()) {
+            try (PreparedStatement statement = connection.prepareStatement("SELECT id, material FROM " + ConfigHandler.prefix + "material_map");
+                    ResultSet results = statement.executeQuery()) {
+                while (results.next()) {
+                    materialTypes.put(results.getInt("id"), MaterialUtils.getType(results.getString("material")));
+                }
+            }
+        }
+
         return new LookupFilter(userId, checkTime, options.getLocation(), options.getRadius(), options.getLimitOffset(), options.getLimitCount(),
-                materialIds(options.getIncludeMaterials()), materialIds(options.getExcludeMaterials()));
+                options.getIncludeMaterials(), options.getExcludeMaterials(), materialTypes);
     }
 
     boolean hasInvalidUser() {
@@ -143,12 +157,16 @@ final class LookupFilter {
     }
 
     void appendMaterialWhere(StringBuilder query, String alias) {
+        appendMaterialWhere(query, alias, false);
+    }
+
+    void appendMaterialWhere(StringBuilder query, String alias, boolean inventoryBlock) {
         String qualifier = alias.isEmpty() ? "" : alias + ".";
-        if (!includeMaterialIds.isEmpty()) {
-            query.append(" AND ").append(qualifier).append("type IN (").append(includeMaterialIds).append(")");
+        if (!includeMaterials.isEmpty()) {
+            query.append(" AND ").append(qualifier).append("type IN (").append(materialIds(includeMaterials, inventoryBlock)).append(")");
         }
-        if (!excludeMaterialIds.isEmpty()) {
-            query.append(" AND ").append(qualifier).append("type NOT IN (").append(excludeMaterialIds).append(")");
+        if (!excludeMaterials.isEmpty()) {
+            query.append(" AND ").append(qualifier).append("type NOT IN (").append(materialIds(excludeMaterials, inventoryBlock)).append(")");
         }
     }
 
@@ -320,16 +338,15 @@ final class LookupFilter {
         return parameterIndex;
     }
 
-    private static String materialIds(List<Material> materials) {
+    private String materialIds(List<Material> materials, boolean inventoryBlock) {
         StringJoiner result = new StringJoiner(",");
-        for (Material material : materials) {
-            result.add(String.valueOf(MaterialUtils.getBlockId(material.name(), false)));
-            int legacyId = BukkitAdapter.ADAPTER.getLegacyBlockId(material);
-            if (legacyId > 0) {
-                result.add(String.valueOf(legacyId));
+        for (Map.Entry<Integer, Material> entry : materialTypes.entrySet()) {
+            Material material = inventoryBlock ? ItemUtils.itemFilter(entry.getValue(), true) : entry.getValue();
+            if (material != null && materials.contains(material)) {
+                result.add(String.valueOf(entry.getKey()));
             }
         }
-        return result.toString();
+        return result.length() == 0 ? "-1" : result.toString();
     }
 
     private static String alias(String alias) {

--- a/src/main/java/net/coreprotect/api/LookupFilter.java
+++ b/src/main/java/net/coreprotect/api/LookupFilter.java
@@ -59,7 +59,7 @@ final class LookupFilter {
             try (PreparedStatement statement = connection.prepareStatement("SELECT id, material FROM " + ConfigHandler.prefix + "material_map");
                     ResultSet results = statement.executeQuery()) {
                 while (results.next()) {
-                    materialTypes.put(results.getInt("id"), MaterialUtils.getType(results.getString("material")));
+                    materialTypes.put(results.getInt("id"), MaterialUtils.getTypeFromStoredName(results.getString("material")));
                 }
             }
         }

--- a/src/main/java/net/coreprotect/api/LookupOptions.java
+++ b/src/main/java/net/coreprotect/api/LookupOptions.java
@@ -1,6 +1,9 @@
 package net.coreprotect.api;
 
+import java.util.List;
+
 import org.bukkit.Location;
+import org.bukkit.Material;
 
 /**
  * Shared options for typed lookup API methods.
@@ -12,6 +15,8 @@ public final class LookupOptions {
     private final Location location;
     private final int limitOffset;
     private final int limitCount;
+    private final List<Material> includeMaterials;
+    private final List<Material> excludeMaterials;
 
     private LookupOptions(Builder builder) {
         this.user = builder.user;
@@ -20,6 +25,8 @@ public final class LookupOptions {
         this.location = builder.location;
         this.limitOffset = builder.limitOffset;
         this.limitCount = builder.limitCount;
+        this.includeMaterials = builder.includeMaterials;
+        this.excludeMaterials = builder.excludeMaterials;
     }
 
     public static Builder builder() {
@@ -54,6 +61,14 @@ public final class LookupOptions {
         return limitOffset >= 0 && limitCount >= 0;
     }
 
+    public List<Material> getIncludeMaterials() {
+        return includeMaterials;
+    }
+
+    public List<Material> getExcludeMaterials() {
+        return excludeMaterials;
+    }
+
     public static final class Builder {
         private String user;
         private int time;
@@ -61,6 +76,8 @@ public final class LookupOptions {
         private Location location;
         private int limitOffset = -1;
         private int limitCount = -1;
+        private List<Material> includeMaterials = List.of();
+        private List<Material> excludeMaterials = List.of();
 
         private Builder() {
         }
@@ -90,6 +107,16 @@ public final class LookupOptions {
         public Builder limit(int offset, int count) {
             this.limitOffset = offset;
             this.limitCount = count;
+            return this;
+        }
+
+        public Builder includeMaterials(List<Material> materials) {
+            this.includeMaterials = List.copyOf(materials);
+            return this;
+        }
+
+        public Builder excludeMaterials(List<Material> materials) {
+            this.excludeMaterials = List.copyOf(materials);
             return this;
         }
 

--- a/src/main/java/net/coreprotect/utility/MaterialUtils.java
+++ b/src/main/java/net/coreprotect/utility/MaterialUtils.java
@@ -140,9 +140,12 @@ public class MaterialUtils extends Queue {
 
     public static Material getType(int id) {
         // Internal ID pulled from DB
+        return id > 0 ? getTypeFromStoredName(getBlockName(id)) : null;
+    }
+
+    public static Material getTypeFromStoredName(String blockName) {
         Material material = null;
-        String blockName = getBlockName(id);
-        if (!blockName.isEmpty() && id > 0) {
+        if (!blockName.isEmpty()) {
             String name = blockName.toUpperCase(Locale.ROOT);
             if (name.contains(NAMESPACE.toUpperCase(Locale.ROOT))) {
                 name = name.split(":")[1];


### PR DESCRIPTION
Adds `includeMaterials` and `excludeMaterials` to `LookupOptions` for item, container, and inventory lookups.

Filtering happens before pagination, including entity-container transactions. Empty filters preserve existing behavior.

Validated on Paper 26.2 build 121 with SQLite: 36 integration assertions covering filtering, pagination, location, and radius using seeded history records.
