### PR TITLE
feat(api): add user filters to typed lookups

### DIFF
--- a/docs/api/version/v13.md
+++ b/docs/api/version/v13.md
@@ -11,6 +11,7 @@ API version 13 adds entity-spawn lookup support while retaining all API version 
 ## Upgrading from API v12
 
 - `LookupOptions` supports material inclusion/exclusion filters for typed container, item, and inventory lookups.
+- `LookupOptions` supports `users(List<String>)` and `excludeUsers(List<String>)` for typed lookups. Inclusion matches any listed user, exclusions take precedence, and an existing `user(...)` remains an additional constraint. Empty lists add no restrictions. As with `user(...)`, an empty name or `#global` matches all users. Username history resolves these filters by UUID, including historical names.
 - Added `CoreProtectAction.ENTITY_SPAWN` with action ID `13`.
 - Added `CoreProtectPreLogEvent.Action.ENTITY_SPAWN`.
 - `BlockResult#getEntityType()` recognizes entity-spawn results.

--- a/docs/api/version/v13.md
+++ b/docs/api/version/v13.md
@@ -10,8 +10,7 @@ API version 13 adds entity-spawn lookup support while retaining all API version 
 
 ## Upgrading from API v12
 
-- `LookupOptions` supports material inclusion/exclusion filters for typed container, item, and inventory lookups.
-- `LookupOptions` supports `users(List<String>)` and `excludeUsers(List<String>)` for typed lookups. Inclusion matches any listed user, exclusions take precedence, and an existing `user(...)` remains an additional constraint. Empty lists add no restrictions. As with `user(...)`, an empty name or `#global` matches all users. Username history resolves these filters by UUID, including historical names.
+- `LookupOptions` supports material inclusion/exclusion filters for typed container, item, and inventory lookups, and `users(List<String>)` / `excludeUsers(List<String>)` filters for all typed lookups.
 - Added `CoreProtectAction.ENTITY_SPAWN` with action ID `13`.
 - Added `CoreProtectPreLogEvent.Action.ENTITY_SPAWN`.
 - `BlockResult#getEntityType()` recognizes entity-spawn results.

--- a/src/main/java/net/coreprotect/api/BlockAPI.java
+++ b/src/main/java/net/coreprotect/api/BlockAPI.java
@@ -158,6 +158,7 @@ public class BlockAPI {
             if (userId != null) {
                 query.append(" AND ").append(ConfigHandler.databaseType.getUserColumn()).append(" = ?");
             }
+            LookupFilter.appendUserWhere(query, "", LookupFilter.userIds(connection, options.getUsers()), LookupFilter.userIds(connection, options.getExcludeUsers()));
             query.append(" ORDER BY ").append(ConfigHandler.getDescendingEventOrder());
             if (options.hasLimit()) {
                 query.append(" LIMIT ").append(options.getLimitCount()).append(" OFFSET ").append(options.getLimitOffset());

--- a/src/main/java/net/coreprotect/api/LookupFilter.java
+++ b/src/main/java/net/coreprotect/api/LookupFilter.java
@@ -30,8 +30,10 @@ final class LookupFilter {
     private final List<Material> includeMaterials;
     private final List<Material> excludeMaterials;
     private final Map<Integer, Material> materialTypes;
+    private final String includeUserIds;
+    private final String excludeUserIds;
 
-    private LookupFilter(Integer userId, int checkTime, Location location, int radius, int limitOffset, int limitCount, List<Material> includeMaterials, List<Material> excludeMaterials, Map<Integer, Material> materialTypes) {
+    private LookupFilter(Integer userId, int checkTime, Location location, int radius, int limitOffset, int limitCount, List<Material> includeMaterials, List<Material> excludeMaterials, Map<Integer, Material> materialTypes, String includeUserIds, String excludeUserIds) {
         this.userId = userId;
         this.checkTime = checkTime;
         this.location = location;
@@ -41,6 +43,8 @@ final class LookupFilter {
         this.includeMaterials = includeMaterials;
         this.excludeMaterials = excludeMaterials;
         this.materialTypes = materialTypes;
+        this.includeUserIds = includeUserIds;
+        this.excludeUserIds = excludeUserIds;
     }
 
     static LookupFilter fromOptions(Connection connection, LookupOptions options) throws Exception {
@@ -65,7 +69,8 @@ final class LookupFilter {
         }
 
         return new LookupFilter(userId, checkTime, options.getLocation(), options.getRadius(), options.getLimitOffset(), options.getLimitCount(),
-                options.getIncludeMaterials(), options.getExcludeMaterials(), materialTypes);
+                options.getIncludeMaterials(), options.getExcludeMaterials(), materialTypes,
+                userIds(connection, options.getUsers()), userIds(connection, options.getExcludeUsers()));
     }
 
     boolean hasInvalidUser() {
@@ -111,6 +116,7 @@ final class LookupFilter {
         if (userId != null) {
             query.append(" AND ").append(qualifier).append(ConfigHandler.databaseType.getUserColumn()).append(" = ?");
         }
+        appendUserWhere(query, alias, includeUserIds, excludeUserIds);
 
         if (location != null) {
             query.append(" AND ").append(qualifier).append("wid = ?");
@@ -130,6 +136,7 @@ final class LookupFilter {
         if (userId != null) {
             query.append(" AND ").append(transaction).append(ConfigHandler.databaseType.getUserColumn()).append(" = ?");
         }
+        appendUserWhere(query, transactionAlias, includeUserIds, excludeUserIds);
         if (location == null) {
             return;
         }
@@ -336,6 +343,32 @@ final class LookupFilter {
             statement.setLong(parameterIndex++, (long) z + 1L);
         }
         return parameterIndex;
+    }
+
+    static String userIds(Connection connection, List<String> users) throws Exception {
+        StringJoiner result = new StringJoiner(",");
+        for (String user : users) {
+            Integer id = MessageAPI.getUserId(connection, user);
+            if (id == null) {
+                // An empty name or #global matches every user.
+                return null;
+            }
+            result.add(String.valueOf(id));
+        }
+        return result.toString();
+    }
+
+    static void appendUserWhere(StringBuilder query, String alias, String includeUserIds, String excludeUserIds) {
+        String column = (alias.isEmpty() ? "" : alias + ".") + ConfigHandler.databaseType.getUserColumn();
+        if (includeUserIds != null && !includeUserIds.isEmpty()) {
+            query.append(" AND ").append(column).append(" IN (").append(includeUserIds).append(")");
+        }
+        if (excludeUserIds == null) {
+            query.append(" AND 1 = 0");
+        }
+        else if (!excludeUserIds.isEmpty()) {
+            query.append(" AND ").append(column).append(" NOT IN (").append(excludeUserIds).append(")");
+        }
     }
 
     private String materialIds(List<Material> materials, boolean inventoryBlock) {

--- a/src/main/java/net/coreprotect/api/LookupOptions.java
+++ b/src/main/java/net/coreprotect/api/LookupOptions.java
@@ -17,6 +17,8 @@ public final class LookupOptions {
     private final int limitCount;
     private final List<Material> includeMaterials;
     private final List<Material> excludeMaterials;
+    private final List<String> users;
+    private final List<String> excludeUsers;
 
     private LookupOptions(Builder builder) {
         this.user = builder.user;
@@ -27,6 +29,8 @@ public final class LookupOptions {
         this.limitCount = builder.limitCount;
         this.includeMaterials = builder.includeMaterials;
         this.excludeMaterials = builder.excludeMaterials;
+        this.users = builder.users;
+        this.excludeUsers = builder.excludeUsers;
     }
 
     public static Builder builder() {
@@ -69,6 +73,14 @@ public final class LookupOptions {
         return excludeMaterials;
     }
 
+    public List<String> getUsers() {
+        return users;
+    }
+
+    public List<String> getExcludeUsers() {
+        return excludeUsers;
+    }
+
     public static final class Builder {
         private String user;
         private int time;
@@ -78,6 +90,8 @@ public final class LookupOptions {
         private int limitCount = -1;
         private List<Material> includeMaterials = List.of();
         private List<Material> excludeMaterials = List.of();
+        private List<String> users = List.of();
+        private List<String> excludeUsers = List.of();
 
         private Builder() {
         }
@@ -117,6 +131,16 @@ public final class LookupOptions {
 
         public Builder excludeMaterials(List<Material> materials) {
             this.excludeMaterials = List.copyOf(materials);
+            return this;
+        }
+
+        public Builder users(List<String> users) {
+            this.users = List.copyOf(users);
+            return this;
+        }
+
+        public Builder excludeUsers(List<String> users) {
+            this.excludeUsers = List.copyOf(users);
             return this;
         }
 

--- a/src/main/java/net/coreprotect/api/UsernameAPI.java
+++ b/src/main/java/net/coreprotect/api/UsernameAPI.java
@@ -50,6 +50,25 @@ public class UsernameAPI {
                 return result;
             }
 
+            Set<String> includedUuids = getUuids(connection, options.getUsers());
+            if (!options.getUsers().isEmpty() && includedUuids != null) {
+                if (uuids.isEmpty()) {
+                    uuids.addAll(includedUuids);
+                }
+                else {
+                    uuids.retainAll(includedUuids);
+                }
+                if (uuids.isEmpty()) {
+                    return result;
+                }
+            }
+            Set<String> excludedUuids = getUuids(connection, options.getExcludeUsers());
+            if (excludedUuids == null) {
+                return result;
+            }
+            // A NULL in NOT IN would also exclude unrelated users.
+            excludedUuids.remove(null);
+
             int checkTime = 0;
             if (options.getTime() > 0) {
                 checkTime = (int) (System.currentTimeMillis() / 1000L) - options.getTime();
@@ -62,6 +81,11 @@ public class UsernameAPI {
                 appendPlaceholders(query, uuids.size());
                 query.append(")");
             }
+            if (!excludedUuids.isEmpty()) {
+                query.append(" AND uuid NOT IN (");
+                appendPlaceholders(query, excludedUuids.size());
+                query.append(")");
+            }
             query.append(" ORDER BY ").append(ConfigHandler.getDescendingEventOrder());
             if (options.hasLimit()) {
                 query.append(" LIMIT ").append(options.getLimitCount()).append(" OFFSET ").append(options.getLimitOffset());
@@ -71,6 +95,9 @@ public class UsernameAPI {
                 int parameterIndex = 1;
                 statement.setInt(parameterIndex++, checkTime);
                 for (String uuid : uuids) {
+                    statement.setString(parameterIndex++, uuid);
+                }
+                for (String uuid : excludedUuids) {
                     statement.setString(parameterIndex++, uuid);
                 }
 
@@ -128,6 +155,21 @@ public class UsernameAPI {
         }
 
         return result.isEmpty() ? null : result;
+    }
+
+    private static Set<String> getUuids(Connection connection, List<String> users) throws Exception {
+        Set<String> result = new LinkedHashSet<>();
+        for (String user : users) {
+            Set<String> matches = getUuids(connection, user);
+            if (matches != null) {
+                if (matches.isEmpty()) {
+                    // An empty name or #global matches every user.
+                    return null;
+                }
+                result.addAll(matches);
+            }
+        }
+        return result;
     }
 
     private static boolean looksLikeUuid(String value) {

--- a/src/main/java/net/coreprotect/api/UsernameAPI.java
+++ b/src/main/java/net/coreprotect/api/UsernameAPI.java
@@ -45,23 +45,11 @@ public class UsernameAPI {
                 return result;
             }
 
-            Set<String> uuids = getUuids(connection, options.getUser());
+            Set<String> uuids = getUuids(connection, options);
             if (uuids == null) {
                 return result;
             }
 
-            Set<String> includedUuids = getUuids(connection, options.getUsers());
-            if (!options.getUsers().isEmpty() && includedUuids != null) {
-                if (uuids.isEmpty()) {
-                    uuids.addAll(includedUuids);
-                }
-                else {
-                    uuids.retainAll(includedUuids);
-                }
-                if (uuids.isEmpty()) {
-                    return result;
-                }
-            }
             Set<String> excludedUuids = getUuids(connection, options.getExcludeUsers());
             if (excludedUuids == null) {
                 return result;
@@ -122,6 +110,25 @@ public class UsernameAPI {
             }
             query.append("?");
         }
+    }
+
+    private static Set<String> getUuids(Connection connection, LookupOptions options) throws Exception {
+        Set<String> result = getUuids(connection, options.getUser());
+        if (result == null || options.getUsers().isEmpty()) {
+            return result;
+        }
+
+        Set<String> includedUuids = getUuids(connection, options.getUsers());
+        if (includedUuids == null) {
+            return result;
+        }
+        if (result.isEmpty()) {
+            result.addAll(includedUuids);
+        }
+        else {
+            result.retainAll(includedUuids);
+        }
+        return result.isEmpty() ? null : result;
     }
 
     private static Set<String> getUuids(Connection connection, String user) throws Exception {


### PR DESCRIPTION
Adds `users` and `excludeUsers` to `LookupOptions` so typed lookups can include multiple users or exclude users before pagination.

The existing `user(...)` keeps its behavior and remains an additional constraint. Username history resolves these filters by UUID, including historical names.

Validated on Paper 26.2 build 121 with SQLite and DuckDB using seeded history, covering all nine typed lookups, user combinations, locations, time, and pagination. Existing material-filter regression checks also pass.
