### PR TITLE
feat(api): add action filters to typed transaction lookups

### DIFF
--- a/docs/api/version/v13.md
+++ b/docs/api/version/v13.md
@@ -11,6 +11,7 @@ API version 13 adds entity-spawn lookup support while retaining all API version 
 ## Upgrading from API v12
 
 - `LookupOptions` supports material inclusion/exclusion filters for typed container, item, and inventory lookups, and `users(List<String>)` / `excludeUsers(List<String>)` filters for all typed lookups.
+- `LookupOptions` supports `containerActions(List<ContainerAction>)`, `itemActions(List<ItemAction>)`, and `inventoryActions(List<InventoryAction>)` for their respective typed lookups. Multiple actions are matched with OR before pagination; empty lists retain the existing behavior, and filters for other lookup types are ignored.
 - Added `CoreProtectAction.ENTITY_SPAWN` with action ID `13`.
 - Added `CoreProtectPreLogEvent.Action.ENTITY_SPAWN`.
 - `BlockResult#getEntityType()` recognizes entity-spawn results.
@@ -25,5 +26,9 @@ Radius lookups match entity spawns at either their original spawn location or th
 Command filters present boats and minecarts as block changes: `a:+block` includes placements, `a:-block` includes destruction, and `a:block` includes both. The corresponding `a:spawn` and `a:kill` filters exclude those aliased vehicle records. This is a command and display alias only; API results and action lists continue to identify the rows as `CoreProtectAction.ENTITY_SPAWN` (action ID `13`) and `CoreProtectAction.ENTITY_KILL` (action ID `3`).
 
 Entity-container location filters match either the transaction's immutable original location or the entity's persisted current/final location, and typed results expose the persisted current/final location. The persisted position is checkpointed when a transaction is logged and during relevant entity lifecycle changes; the synchronous typed APIs do not schedule blocking live-entity scans.
+
+Inventory action filters identify the original source and transaction, not the normalized inventory direction. For example, `InventoryAction.BLOCK_PLACE` and `InventoryAction.CONTAINER_ADD` select different events even though both remove an item from the player's inventory. Container action filters include tracked entity-container transactions.
+
+Item lookups without an action filter continue to exclude `BREAK`, `DESTROY`, `CREATE`, `SELL`, and `BUY`. These actions can be selected explicitly with `itemActions`.
 
 API rollback and restore methods return an empty result without performing any changes while a database purge is in progress.

--- a/docs/api/version/v13.md
+++ b/docs/api/version/v13.md
@@ -11,7 +11,7 @@ API version 13 adds entity-spawn lookup support while retaining all API version 
 ## Upgrading from API v12
 
 - `LookupOptions` supports material inclusion/exclusion filters for typed container, item, and inventory lookups, and `users(List<String>)` / `excludeUsers(List<String>)` filters for all typed lookups.
-- `LookupOptions` supports `containerActions(List<ContainerAction>)`, `itemActions(List<ItemAction>)`, and `inventoryActions(List<InventoryAction>)` for their respective typed lookups. Multiple actions are matched with OR before pagination; empty lists retain the existing behavior, and filters for other lookup types are ignored.
+- `LookupOptions` supports `containerActions(List<ContainerAction>)`, `itemActions(List<ItemAction>)`, and `inventoryActions(List<InventoryAction>)` to select events returned by `containerLookup`, `itemLookup`, and `inventoryLookup`, respectively. Each filter only affects its corresponding lookup. Select multiple actions to match any of them, or omit the filter or pass an empty list to keep the default results.
 - Added `CoreProtectAction.ENTITY_SPAWN` with action ID `13`.
 - Added `CoreProtectPreLogEvent.Action.ENTITY_SPAWN`.
 - `BlockResult#getEntityType()` recognizes entity-spawn results.
@@ -27,8 +27,8 @@ Command filters present boats and minecarts as block changes: `a:+block` include
 
 Entity-container location filters match either the transaction's immutable original location or the entity's persisted current/final location, and typed results expose the persisted current/final location. The persisted position is checkpointed when a transaction is logged and during relevant entity lifecycle changes; the synchronous typed APIs do not schedule blocking live-entity scans.
 
-Inventory action filters identify the original source and transaction, not the normalized inventory direction. For example, `InventoryAction.BLOCK_PLACE` and `InventoryAction.CONTAINER_ADD` select different events even though both remove an item from the player's inventory. Container action filters include tracked entity-container transactions.
+To find items deposited into containers, use `containerActions(List.of(ContainerAction.ADD))`. For inventory lookups, select `InventoryAction.CONTAINER_ADD` for deposits or `InventoryAction.BLOCK_PLACE` for block placement. Container filters also cover tracked boat and minecart transactions.
 
-Item lookups without an action filter continue to exclude `BREAK`, `DESTROY`, `CREATE`, `SELL`, and `BUY`. These actions can be selected explicitly with `itemActions`.
+For example, `itemActions(List.of(ItemAction.DROP, ItemAction.PICKUP))` selects dropped and picked-up items. To query `ItemAction.BREAK`, `DESTROY`, `CREATE`, `SELL`, or `BUY`, select them explicitly with `itemActions`; these events are not included by default.
 
 API rollback and restore methods return an empty result without performing any changes while a database purge is in progress.

--- a/src/main/java/net/coreprotect/api/BlockAPI.java
+++ b/src/main/java/net/coreprotect/api/BlockAPI.java
@@ -224,6 +224,10 @@ public class BlockAPI {
             return result;
         }
 
+        if (options == null) {
+            options = LookupOptions.builder().build();
+        }
+
         try (Connection connection = Database.getConnection(false, 1000)) {
             if (connection == null) {
                 return result;
@@ -239,9 +243,12 @@ public class BlockAPI {
                 StringBuilder containerWhere = new StringBuilder();
                 filter.appendWhere(containerWhere, "container_rows");
                 filter.appendMaterialWhere(containerWhere, "container_rows");
+                int[] actions = options.getContainerActions().stream().mapToInt(ContainerAction::id).toArray();
+                LookupFilter.appendActionWhere(containerWhere, "container_rows", actions);
                 StringBuilder entityWhere = new StringBuilder();
                 filter.appendEntityContainerWhere(entityWhere, "entity_rows", "spawn_rows");
                 filter.appendMaterialWhere(entityWhere, "entity_rows");
+                LookupFilter.appendActionWhere(entityWhere, "entity_rows", actions);
 
                 StringBuilder query = new StringBuilder("SELECT * FROM (");
                 query.append("SELECT 0 AS source,container_rows.rowid AS id,container_rows.time,container_rows.").append(ConfigHandler.databaseType.getUserColumn()).append(",container_rows.wid,container_rows.x,container_rows.y,container_rows.z,container_rows.action,container_rows.type,container_rows.data,container_rows.amount,container_rows.metadata,container_rows.rolled_back FROM ")

--- a/src/main/java/net/coreprotect/api/ContainerAction.java
+++ b/src/main/java/net/coreprotect/api/ContainerAction.java
@@ -1,0 +1,21 @@
+package net.coreprotect.api;
+
+import net.coreprotect.model.item.ItemTransactionActions;
+
+/**
+ * Container transaction actions used by typed container lookup filters.
+ */
+public enum ContainerAction {
+    REMOVE(ItemTransactionActions.REMOVE),
+    ADD(ItemTransactionActions.ADD);
+
+    private final int id;
+
+    ContainerAction(int id) {
+        this.id = id;
+    }
+
+    public int id() {
+        return id;
+    }
+}

--- a/src/main/java/net/coreprotect/api/InventoryAPI.java
+++ b/src/main/java/net/coreprotect/api/InventoryAPI.java
@@ -5,6 +5,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.StringJoiner;
 
 import net.coreprotect.api.result.InventoryResult;
 import net.coreprotect.config.Config;
@@ -62,6 +63,7 @@ public class InventoryAPI {
                         blockWhereBuilder.toString(),
                         where,
                         entityWhereBuilder.toString(),
+                        options.getInventoryActions(),
                         options.hasLimit(),
                         filter.table(connection, "block", ""),
                         filter.table(connection, "container", ""),
@@ -97,7 +99,7 @@ public class InventoryAPI {
         return result;
     }
 
-    private static String buildQuery(String blockWhere, String where, String entityWhere, boolean hasLimit, String blockTable, String containerTable, String entityContainerTable, String itemTable) {
+    private static String buildQuery(String blockWhere, String where, String entityWhere, List<InventoryAction> actions, boolean hasLimit, String blockTable, String containerTable, String entityContainerTable, String itemTable) {
         StringBuilder query = new StringBuilder("SELECT * FROM (");
         query.append("SELECT 0 AS source,rowid AS id,time,").append(ConfigHandler.databaseType.getUserColumn()).append(",wid,x,y,z,type,data,1 AS amount,meta AS metadata,action,rolled_back FROM ")
                 .append(blockTable).append(' ').append(blockWhere).append(" AND action = 1");
@@ -110,12 +112,28 @@ public class InventoryAPI {
         query.append(" UNION ALL ");
         query.append("SELECT 2 AS source,rowid AS id,time,").append(ConfigHandler.databaseType.getUserColumn()).append(",wid,x,y,z,type,0 AS data,amount,data AS metadata,action,rolled_back FROM ")
                 .append(itemTable).append(' ').append(where);
-        query.append(") AS inventory_lookup ORDER BY time DESC, source DESC, id DESC");
+        query.append(") AS inventory_lookup");
+        appendActionWhere(query, actions);
+        query.append(" ORDER BY time DESC, source DESC, id DESC");
         if (hasLimit) {
             query.append(" LIMIT ? OFFSET ?");
         }
 
         return query.toString();
+    }
+
+    private static void appendActionWhere(StringBuilder query, List<InventoryAction> actions) {
+        if (!actions.isEmpty()) {
+            StringJoiner predicates = new StringJoiner(" OR ");
+            for (InventoryAction action : actions) {
+                String sources = String.valueOf(action.sourceId());
+                if (action.sourceId() == InventorySources.CONTAINER) {
+                    sources += "," + InventorySources.ENTITY_CONTAINER;
+                }
+                predicates.add("(source IN (" + sources + ") AND action = " + action.id() + ")");
+            }
+            query.append(" WHERE (").append(predicates).append(")");
+        }
     }
 
     private static InventoryResult parseInventoryResult(Connection connection, ResultSet results) throws Exception {

--- a/src/main/java/net/coreprotect/api/InventoryAction.java
+++ b/src/main/java/net/coreprotect/api/InventoryAction.java
@@ -1,0 +1,42 @@
+package net.coreprotect.api;
+
+import net.coreprotect.model.action.LookupActions;
+import net.coreprotect.model.item.InventorySources;
+import net.coreprotect.model.item.ItemTransactionActions;
+
+/**
+ * Source-specific transaction actions used by typed inventory lookup filters.
+ * Container actions include tracked entity-container transactions.
+ */
+public enum InventoryAction {
+    BLOCK_PLACE(InventorySources.BLOCK, LookupActions.BLOCK_PLACE),
+    CONTAINER_REMOVE(InventorySources.CONTAINER, ItemTransactionActions.REMOVE),
+    CONTAINER_ADD(InventorySources.CONTAINER, ItemTransactionActions.ADD),
+    ITEM_DROP(InventorySources.ITEM, ItemTransactionActions.DROP),
+    ITEM_PICKUP(InventorySources.ITEM, ItemTransactionActions.PICKUP),
+    ITEM_REMOVE_ENDER(InventorySources.ITEM, ItemTransactionActions.REMOVE_ENDER),
+    ITEM_ADD_ENDER(InventorySources.ITEM, ItemTransactionActions.ADD_ENDER),
+    ITEM_THROW(InventorySources.ITEM, ItemTransactionActions.THROW),
+    ITEM_SHOOT(InventorySources.ITEM, ItemTransactionActions.SHOOT),
+    ITEM_BREAK(InventorySources.ITEM, ItemTransactionActions.BREAK),
+    ITEM_DESTROY(InventorySources.ITEM, ItemTransactionActions.DESTROY),
+    ITEM_CREATE(InventorySources.ITEM, ItemTransactionActions.CREATE),
+    ITEM_SELL(InventorySources.ITEM, ItemTransactionActions.SELL),
+    ITEM_BUY(InventorySources.ITEM, ItemTransactionActions.BUY);
+
+    private final int sourceId;
+    private final int id;
+
+    InventoryAction(int sourceId, int id) {
+        this.sourceId = sourceId;
+        this.id = id;
+    }
+
+    public int sourceId() {
+        return sourceId;
+    }
+
+    public int id() {
+        return id;
+    }
+}

--- a/src/main/java/net/coreprotect/api/ItemAPI.java
+++ b/src/main/java/net/coreprotect/api/ItemAPI.java
@@ -32,6 +32,10 @@ public class ItemAPI {
             return result;
         }
 
+        if (options == null) {
+            options = LookupOptions.builder().build();
+        }
+
         try (Connection connection = Database.getConnection(false, 1000)) {
             if (connection == null) {
                 return result;
@@ -49,12 +53,17 @@ public class ItemAPI {
             }
             filter.appendWhere(query);
             filter.appendMaterialWhere(query);
-            query.append(" AND action NOT IN (")
-                    .append(ItemLogger.ITEM_BREAK).append(",")
-                    .append(ItemLogger.ITEM_DESTROY).append(",")
-                    .append(ItemLogger.ITEM_CREATE).append(",")
-                    .append(ItemLogger.ITEM_SELL).append(",")
-                    .append(ItemLogger.ITEM_BUY).append(")");
+            if (options.getItemActions().isEmpty()) {
+                query.append(" AND action NOT IN (")
+                        .append(ItemLogger.ITEM_BREAK).append(",")
+                        .append(ItemLogger.ITEM_DESTROY).append(",")
+                        .append(ItemLogger.ITEM_CREATE).append(",")
+                        .append(ItemLogger.ITEM_SELL).append(",")
+                        .append(ItemLogger.ITEM_BUY).append(")");
+            }
+            else {
+                LookupFilter.appendActionWhere(query, "", options.getItemActions().stream().mapToInt(ItemAction::id).toArray());
+            }
             query.append(" ORDER BY ").append(ConfigHandler.getDescendingEventOrder());
             filter.appendLimit(query);
 

--- a/src/main/java/net/coreprotect/api/ItemAction.java
+++ b/src/main/java/net/coreprotect/api/ItemAction.java
@@ -1,0 +1,30 @@
+package net.coreprotect.api;
+
+import net.coreprotect.model.item.ItemTransactionActions;
+
+/**
+ * Item transaction actions used by typed item lookup filters.
+ */
+public enum ItemAction {
+    DROP(ItemTransactionActions.DROP),
+    PICKUP(ItemTransactionActions.PICKUP),
+    REMOVE_ENDER(ItemTransactionActions.REMOVE_ENDER),
+    ADD_ENDER(ItemTransactionActions.ADD_ENDER),
+    THROW(ItemTransactionActions.THROW),
+    SHOOT(ItemTransactionActions.SHOOT),
+    BREAK(ItemTransactionActions.BREAK),
+    DESTROY(ItemTransactionActions.DESTROY),
+    CREATE(ItemTransactionActions.CREATE),
+    SELL(ItemTransactionActions.SELL),
+    BUY(ItemTransactionActions.BUY);
+
+    private final int id;
+
+    ItemAction(int id) {
+        this.id = id;
+    }
+
+    public int id() {
+        return id;
+    }
+}

--- a/src/main/java/net/coreprotect/api/LookupFilter.java
+++ b/src/main/java/net/coreprotect/api/LookupFilter.java
@@ -168,6 +168,16 @@ final class LookupFilter {
         query.append("))");
     }
 
+    static void appendActionWhere(StringBuilder query, String alias, int[] actions) {
+        if (actions.length > 0) {
+            StringJoiner ids = new StringJoiner(",");
+            for (int action : actions) {
+                ids.add(String.valueOf(action));
+            }
+            query.append(" AND ").append(alias.isEmpty() ? "" : alias + ".").append("action IN (").append(ids).append(")");
+        }
+    }
+
     void appendMaterialWhere(StringBuilder query) {
         appendMaterialWhere(query, "");
     }

--- a/src/main/java/net/coreprotect/api/LookupOptions.java
+++ b/src/main/java/net/coreprotect/api/LookupOptions.java
@@ -19,6 +19,9 @@ public final class LookupOptions {
     private final List<Material> excludeMaterials;
     private final List<String> users;
     private final List<String> excludeUsers;
+    private final List<ContainerAction> containerActions;
+    private final List<ItemAction> itemActions;
+    private final List<InventoryAction> inventoryActions;
 
     private LookupOptions(Builder builder) {
         this.user = builder.user;
@@ -31,6 +34,9 @@ public final class LookupOptions {
         this.excludeMaterials = builder.excludeMaterials;
         this.users = builder.users;
         this.excludeUsers = builder.excludeUsers;
+        this.containerActions = builder.containerActions;
+        this.itemActions = builder.itemActions;
+        this.inventoryActions = builder.inventoryActions;
     }
 
     public static Builder builder() {
@@ -81,6 +87,18 @@ public final class LookupOptions {
         return excludeUsers;
     }
 
+    public List<ContainerAction> getContainerActions() {
+        return containerActions;
+    }
+
+    public List<ItemAction> getItemActions() {
+        return itemActions;
+    }
+
+    public List<InventoryAction> getInventoryActions() {
+        return inventoryActions;
+    }
+
     public static final class Builder {
         private String user;
         private int time;
@@ -92,6 +110,9 @@ public final class LookupOptions {
         private List<Material> excludeMaterials = List.of();
         private List<String> users = List.of();
         private List<String> excludeUsers = List.of();
+        private List<ContainerAction> containerActions = List.of();
+        private List<ItemAction> itemActions = List.of();
+        private List<InventoryAction> inventoryActions = List.of();
 
         private Builder() {
         }
@@ -141,6 +162,21 @@ public final class LookupOptions {
 
         public Builder excludeUsers(List<String> users) {
             this.excludeUsers = List.copyOf(users);
+            return this;
+        }
+
+        public Builder containerActions(List<ContainerAction> actions) {
+            this.containerActions = List.copyOf(actions);
+            return this;
+        }
+
+        public Builder itemActions(List<ItemAction> actions) {
+            this.itemActions = List.copyOf(actions);
+            return this;
+        }
+
+        public Builder inventoryActions(List<InventoryAction> actions) {
+            this.inventoryActions = List.copyOf(actions);
             return this;
         }
 


### PR DESCRIPTION
## Summary

Adds `containerActions`, `itemActions`, and `inventoryActions` to `LookupOptions`, allowing callers to select specific events. Empty or omitted filters preserve existing behavior.

## Approach

I considered three options:

**A. Shared ADD/REMOVE filter**, similar to the direction filters in `/co lookup`. For inventory lookups, dropping an item, placing a block, and depositing items into a container would all fall under REMOVE.

**B. Explicit actions**, with separate `ContainerAction`, `ItemAction`, and `InventoryAction` enums.

**C. Both**, keeping explicit actions for precise queries and adding ADD/REMOVE for convenience. When both filters are specified, events would need to match both.

This PR currently implements option B because API callers may need to distinguish events with the same inventory direction. Option C could build on this in a follow-up PR, so callers wouldn't have to maintain their own direction-to-action mapping.

@Intelli, which approach would you prefer? I can switch to option A or add direction filters as in option C.

## Compatibility

The implementation stays within the typed lookup flow; command and legacy lookups are unchanged. Explicit item filters also allow selecting `BREAK`, `DESTROY`, `CREATE`, `SELL`, and `BUY` events, which remain excluded from item lookups by default.
