### PR TITLE
Add dispensers config option to disable dispenser logging (fixes #727)

### DIFF
--- a/src/main/java/net/coreprotect/config/Config.java
+++ b/src/main/java/net/coreprotect/config/Config.java
@@ -78,6 +78,7 @@ public class Config extends Language {
     public boolean NATURAL_BREAK;
     public boolean BLOCK_MOVEMENT;
     public boolean PISTONS;
+    public boolean DISPENSERS;
     public boolean BLOCK_BURN;
     public boolean BLOCK_IGNITE;
     public boolean FIRE_EXTINGUISH;
@@ -149,6 +150,7 @@ public class Config extends Language {
         DEFAULT_VALUES.put("natural-break", "true");
         DEFAULT_VALUES.put("block-movement", "true");
         DEFAULT_VALUES.put("pistons", "true");
+        DEFAULT_VALUES.put("dispensers", "true");
         DEFAULT_VALUES.put("block-burn", "true");
         DEFAULT_VALUES.put("block-ignite", "true");
         DEFAULT_VALUES.put("fire-extinguish", "false");
@@ -199,6 +201,7 @@ public class Config extends Language {
         HEADERS.put("natural-break", new String[] { "# Logs blocks that break off of other blocks; for example, a sign or torch", "# falling off of a dirt block that a player breaks. This is required for", "# beds/doors to properly rollback." });
         HEADERS.put("block-movement", new String[] { "# Properly track block movement, such as sand or gravel falling." });
         HEADERS.put("pistons", new String[] { "# Properly track blocks moved by pistons." });
+        HEADERS.put("dispensers", new String[] { "# Logs world changes caused by dispensers, such as dispensing water,", "# lava, or fire, and the growth caused by dispensed bone meal." });
         HEADERS.put("block-burn", new String[] { "# Logs blocks that burn up in a fire." });
         HEADERS.put("block-ignite", new String[] { "# Logs when a block naturally ignites, such as from fire spreading." });
         HEADERS.put("fire-extinguish", new String[] { "# Logs when fire naturally extinguishes." });
@@ -279,6 +282,7 @@ public class Config extends Language {
         this.NATURAL_BREAK = this.getBoolean("natural-break");
         this.BLOCK_MOVEMENT = this.getBoolean("block-movement");
         this.PISTONS = this.getBoolean("pistons");
+        this.DISPENSERS = this.getBoolean("dispensers");
         this.BLOCK_BURN = this.getBoolean("block-burn");
         this.BLOCK_IGNITE = this.getBoolean("block-ignite");
         this.FIRE_EXTINGUISH = this.getBoolean("fire-extinguish");

--- a/src/main/java/net/coreprotect/listener/block/BlockDispenseListener.java
+++ b/src/main/java/net/coreprotect/listener/block/BlockDispenseListener.java
@@ -96,6 +96,11 @@ public final class BlockDispenseListener extends Queue implements Listener {
                     }
                 }
 
+                // The item transaction and bone meal hand-off above are unaffected by this option.
+                if (!config.DISPENSERS) {
+                    return;
+                }
+
                 if (type == Material.FIRE && (!config.BLOCK_IGNITE || !(newBlockData instanceof Lightable))) {
                     return;
                 }

--- a/src/main/java/net/coreprotect/listener/block/BlockFertilizeListener.java
+++ b/src/main/java/net/coreprotect/listener/block/BlockFertilizeListener.java
@@ -72,6 +72,10 @@ public final class BlockFertilizeListener extends Queue implements Listener {
             }
         }
 
+        if (!config.DISPENSERS && ("#dispenser".equals(user) || "#bonemeal".equals(user))) {
+            return;
+        }
+
         if (config.DUPLICATE_SUPPRESSION && "#dispenser".equals(user) && shouldSuppressBonemealDuplicate(location, blocks)) {
             return;
         }


### PR DESCRIPTION
Adds a dispensers config option that controls whether CoreProtect logs the world changes a dispenser causes. It defaults to true, so existing installations keep their current behavior. Fixes #727.

## Problem
#727 asks for a way to stop dispensers from writing a row for every block they change, which adds up fast on farms, without turning off player block logging. Setting `block-place: false` stops those rows today, but it stops player block logging with them. A comment in the issue also asks for dispensed bone meal.

## Fix
`Config.java` gains a `DISPENSERS` field, a `dispensers` entry in the generated config.yml, and a header explaining it, placed after `pistons`.

Three listeners read it.

`BlockDispenseListener` returns before queueing any world change when the option is off. The return sits after the dispenser item transaction and after the bone meal hand-off, so neither is affected.

`BlockFertilizeListener` skips growth attributed to a dispenser. The hand-off in `BlockDispenseListener` records the block a dispenser's bone meal was applied to, and it does so only when the block is an actual dispenser, so a dropper ejecting bone meal cannot claim a block that another plugin then grows. Bone meal that other plugins apply without a player stays `#bonemeal` and is still logged.

`BlockIgniteListener` skips ignition caused by a dispenser. Flint and steel is matched through `getIgnitingBlock()`. A fire charge becomes a fireball that reports no igniting block, so it is matched through the fireball's shooter being a `BlockProjectileSource`, which still identifies the dispenser after the block itself has been broken.

## Testing
Build: `mvn -B verify` on JDK 25, BUILD SUCCESS.

Live: Paper 26.2 build 123, flat world, DuckDB storage, CoreProtect built from this branch. I drove the server over RCON and read the plugin's DuckDB tables afterwards. A helper plugin applies bone meal with no player for the other-plugin cases, including from a dropper's own dispense event when testing whether a dropper can claim the block.

With `dispensers: true`:

- A dropper ejecting bone meal at (300,-59,450) grew nothing on its own, and bone meal that the helper plugin then applied to (310,-60,450) in the same tick was logged as `#bonemeal`. Before this revision that row was logged as `#dispenser`.
- A bone meal dispenser grew the wheat at (320,-60,450) and logged `#dispenser` there.
- A flint and steel dispenser lit fire at (331,-60,450), logged as `#fire`.
- A fire charge dispenser wrote `#fire` at (340,-60,450) with the dispenser in place, and at (351,-60,450) when the dispenser was removed while the fireball was still in the air. The removal was confirmed with `execute if block` before the fireball landed.
- Bone meal applied by the helper plugin with no dispenser involved wrote `#bonemeal` at (360,-60,450).
- Water and lava buckets dispensed into enclosed pockets placed water at (390,-60,450) and lava at (395,-60,450), both logged as `#dispenser`. Water dispensed onto open ground at (400,-60,450) was logged as `#dispenser`, and the blocks the water spread into were logged as `#water`.

With `dispensers: false`, applied by `/co reload`:

- The bone meal dispenser at (320,-60,470), the flint and steel dispenser at (331,-60,470), the fire charge dispenser at (340,-60,470), and the water and lava buckets at (390,-60,470) and (395,-60,470) all changed the world (checked with `execute if block`) and wrote no block rows.
- The fire charge whose dispenser was removed before impact wrote no block rows, while the ignition still fired.
- Bone meal applied by the helper plugin at (360,-60,470) still wrote `#bonemeal`, and the water flowing from (400,-60,470) still wrote `#water` rows.
- Dispenser and dropper item transactions were still written in both configurations.

Not tested: entities spawned by dispensers, and per-world configuration files.

## Notes
Dispenser and dropper item transactions stay under `item-transactions`, and entities that dispensers spawn stay under `entity-spawns`. Water or lava that flows after a dispenser places the source is still logged under `water-flow` and `lava-flow`, like any other source. Only the initial ignition is attributed to the dispenser; fire that spreads afterwards has no dispenser source and is logged as before.

TNT primed by a dispenser's flint and steel keeps its current attribution. Both the TNT break row and the explosion rows are written as `#tnt`, and both follow the `explosions` option: they disappear with `explosions: false` and stay in place with `dispensers: false`. The dispenser is not named on those rows.

`docs/config.md` does not list the logging options, so the option is documented in its config.yml header. Happy to add a section to that page as well.
